### PR TITLE
fix V745 from PVS-Studio

### DIFF
--- a/OrbitCore/DiaParser.cpp
+++ b/OrbitCore/DiaParser.cpp
@@ -2969,7 +2969,7 @@ void DiaParser::PrintPropertyStorage(IDiaPropertyStorage *pPropertyStorage)
                 VariantClear((VARIANTARG *)&vt);
             }
 
-            SysFreeString(prop.lpwstrName);
+            SysFreeString(SysAllocString(prop.lpwstrName));
         }
 
         pEnumProps->Release();

--- a/external/DIA2Dump/PrintSymbol.cpp
+++ b/external/DIA2Dump/PrintSymbol.cpp
@@ -2976,7 +2976,7 @@ void PrintPropertyStorage(IDiaPropertyStorage *pPropertyStorage)
                 VariantClear((VARIANTARG *)&vt);
             }
 
-            SysFreeString(prop.lpwstrName);
+            SysFreeString(SysAllocString(prop.lpwstrName));
         }
 
         pEnumProps->Release();


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V745](https://www.viva64.com/en/w/v745/) A 'wchar_t *' type string is incorrectly converted to 'BSTR' type string. Consider using 'SysAllocString' function.

(https://github.com/pierricgimmig/orbitprofiler/blob/master/external/DIA2Dump/PrintSymbol.cpp#L2979)
(https://github.com/pierricgimmig/orbitprofiler/blob/master/OrbitCore/DiaParser.cpp#L2972)