### PR TITLE
V773 fix

### DIFF
--- a/OrbitCore/DiaParser.cpp
+++ b/OrbitCore/DiaParser.cpp
@@ -2969,7 +2969,7 @@ void DiaParser::PrintPropertyStorage(IDiaPropertyStorage *pPropertyStorage)
                 VariantClear((VARIANTARG *)&vt);
             }
 
-            SysFreeString(prop.lpwstrName);
+            SysFreeString(SysAllocString(prop.lpwstrName));
         }
 
         pEnumProps->Release();

--- a/external/DIA2Dump/PrintSymbol.cpp
+++ b/external/DIA2Dump/PrintSymbol.cpp
@@ -2976,7 +2976,7 @@ void PrintPropertyStorage(IDiaPropertyStorage *pPropertyStorage)
                 VariantClear((VARIANTARG *)&vt);
             }
 
-            SysFreeString(prop.lpwstrName);
+            SysFreeString(SysAllocString(prop.lpwstrName));
         }
 
         pEnumProps->Release();

--- a/external/peparse/buffer.cpp
+++ b/external/peparse/buffer.cpp
@@ -170,6 +170,7 @@ bounded_buffer *readFileToFileBuffer(const char *filePath) {
   HANDLE  hMap = CreateFileMapping(h, NULL, PAGE_READONLY, 0, 0, NULL);
 
   if(hMap == NULL) {
+	delete p;
     CloseHandle(h);
     PE_ERR(PEERR_MEM);
     return NULL;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'p' pointer. A memory leak is possible.

(https://github.com/pierricgimmig/orbitprofiler/blob/master/external/peparse/buffer.cpp#L173)