### PR TITLE
Removed unused variable.

### DIFF
--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -162,7 +162,6 @@ bool Pdb::LoadPdb( const wchar_t* a_PdbName )
             std::vector<std::string> tokens = Tokenize(line);
             if (tokens.size() == 2) // bpftrace
             {
-                Function func;
                 auto probeTokens = Tokenize(tokens[1], ":");
                 if (probeTokens.size() == 2)
                 {


### PR DESCRIPTION
The variable `func` gets re-declared and initialized before the first use (about 10 lines after this removed line). The first definition should not be used at all.