### PR TITLE
Fixed the usage of SelectedFunctionsMap

### DIFF
--- a/OrbitCore/BpfTrace.cpp
+++ b/OrbitCore/BpfTrace.cpp
@@ -59,10 +59,11 @@ std::string BpfTrace::GetBpfScript()
     {
         if (func->IsSelected())
         {
+            uint64_t virtual_address = (uint64_t)func->GetVirtualAddress();
             Capture::GSelectedFunctionsMap[func->m_Address] = func;
 
-            ss << "   uprobe:" << func->m_Probe << R"({ printf("b )" << std::to_string((uint64_t)func->GetVirtualAddress()) << R"( %u %lld\n", tid, nsecs); })" << std::endl;
-            ss << "uretprobe:" << func->m_Probe << R"({ printf("e )" << std::to_string((uint64_t)func->GetVirtualAddress()) << R"( %u %lld\n", tid, nsecs); })" << std::endl;
+            ss << "   uprobe:" << func->m_Probe << R"({ printf("b )" << std::to_string(virtual_address) << R"( %u %lld\n", tid, nsecs); })" << std::endl;
+            ss << "uretprobe:" << func->m_Probe << R"({ printf("e )" << std::to_string(virtual_address) << R"( %u %lld\n", tid, nsecs); })" << std::endl;
         }
     }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -202,7 +202,7 @@ void OrbitApp::LoadSystrace(const std::string& a_FileName)
 
     for (Function & func : systrace->GetFunctions())
     {
-        Capture::GSelectedFunctionsMap[func.m_Address] = &func;
+        Capture::GSelectedFunctionsMap[func.GetVirtualAddress()] = &func;
     }
     Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;
 
@@ -230,7 +230,7 @@ void OrbitApp::AppendSystrace(const std::string& a_FileName, uint64_t a_TimeOffs
 
     for (Function& func : systrace->GetFunctions())
     {
-        Capture::GSelectedFunctionsMap[func.m_Address] = &func;
+        Capture::GSelectedFunctionsMap[func.GetVirtualAddress()] = &func;
     }
     Capture::GVisibleFunctionsMap = Capture::GSelectedFunctionsMap;
 


### PR DESCRIPTION
The Capture::GSelectedFunctionsMap should always have the virtual address of the function as key. That was not the case in all usages. This PR fixes this.