### PR TITLE
Fixes #42: Disable Call Stack Navigation Buttons

### DIFF
--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -69,6 +69,7 @@ void SamplingReport::OnSelectAddress( uint64_t a_Address, ThreadID a_ThreadId )
 //-----------------------------------------------------------------------------
 void SamplingReport::IncrementCallstackIndex()
 {
+    assert(m_SelectedSortedCallstackReport);
     int maxIndex = (int)m_SelectedSortedCallstackReport->m_CallStacks.size() - 1;
     if( ++m_SelectedAddressCallstackIndex > maxIndex )
     {
@@ -81,6 +82,7 @@ void SamplingReport::IncrementCallstackIndex()
 //-----------------------------------------------------------------------------
 void SamplingReport::DecrementCallstackIndex()
 {
+    assert(m_SelectedSortedCallstackReport);
     int maxIndex = (int)m_SelectedSortedCallstackReport->m_CallStacks.size() - 1;
     if( --m_SelectedAddressCallstackIndex < 0 )
     {

--- a/OrbitGl/SamplingReport.cpp
+++ b/OrbitGl/SamplingReport.cpp
@@ -69,7 +69,7 @@ void SamplingReport::OnSelectAddress( uint64_t a_Address, ThreadID a_ThreadId )
 //-----------------------------------------------------------------------------
 void SamplingReport::IncrementCallstackIndex()
 {
-    assert(m_SelectedSortedCallstackReport);
+    assert(HasCallstacks());
     int maxIndex = (int)m_SelectedSortedCallstackReport->m_CallStacks.size() - 1;
     if( ++m_SelectedAddressCallstackIndex > maxIndex )
     {
@@ -82,7 +82,7 @@ void SamplingReport::IncrementCallstackIndex()
 //-----------------------------------------------------------------------------
 void SamplingReport::DecrementCallstackIndex()
 {
-    assert(m_SelectedSortedCallstackReport);
+    assert(HasCallstacks());
     int maxIndex = (int)m_SelectedSortedCallstackReport->m_CallStacks.size() - 1;
     if( --m_SelectedAddressCallstackIndex < 0 )
     {

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -25,6 +25,7 @@ public:
     void DecrementCallstackIndex();
     std::wstring GetSelectedCallstackString();
     void SetUiRefreshFunc( std::function<void()> a_Func ){ m_UiRefreshFunc = a_Func; }
+    std::shared_ptr< struct SortedCallstackReport >     m_SelectedSortedCallstackReport;
 
 protected:
     std::shared_ptr< class SamplingProfiler >           m_Profiler;
@@ -32,7 +33,6 @@ protected:
     CallStackDataView*                                  m_CallstackDataView;
     
     unsigned long long                                  m_SelectedAddress;
-    std::shared_ptr< struct SortedCallstackReport >     m_SelectedSortedCallstackReport;
     int                                                 m_SelectedAddressCallstackIndex;
     std::function<void()>                               m_UiRefreshFunc;
 };

--- a/OrbitGl/SamplingReport.h
+++ b/OrbitGl/SamplingReport.h
@@ -25,7 +25,7 @@ public:
     void DecrementCallstackIndex();
     std::wstring GetSelectedCallstackString();
     void SetUiRefreshFunc( std::function<void()> a_Func ){ m_UiRefreshFunc = a_Func; }
-    std::shared_ptr< struct SortedCallstackReport >     m_SelectedSortedCallstackReport;
+    bool HasCallstacks() const { return m_SelectedSortedCallstackReport != nullptr; } 
 
 protected:
     std::shared_ptr< class SamplingProfiler >           m_Profiler;
@@ -33,6 +33,7 @@ protected:
     CallStackDataView*                                  m_CallstackDataView;
     
     unsigned long long                                  m_SelectedAddress;
+    std::shared_ptr< struct SortedCallstackReport >     m_SelectedSortedCallstackReport;
     int                                                 m_SelectedAddressCallstackIndex;
     std::function<void()>                               m_UiRefreshFunc;
 };

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -13,6 +13,13 @@ OrbitSamplingReport::OrbitSamplingReport(QWidget *parent) : QWidget(parent)
                                                           , ui(new Ui::OrbitSamplingReport)
 {
     ui->setupUi(this);
+    if (!m_SamplingReport || !m_SamplingReport->m_SelectedSortedCallstackReport)
+    {
+        ui->NextCallstackButton->setEnabled(false);
+        ui->NextCallstackButton->setStyleSheet(QString::fromUtf8("QPushButton:disabled{ color: gray }"));
+        ui->PreviousCallstackButton->setEnabled(false);
+        ui->PreviousCallstackButton->setStyleSheet(QString::fromUtf8("QPushButton:disabled{ color: gray }"));
+    }
 
     QList<int> sizes;
     sizes.append( 5000 );
@@ -81,6 +88,11 @@ void OrbitSamplingReport::on_PreviousCallstackButton_clicked()
 void OrbitSamplingReport::Refresh()
 {
     assert(m_SamplingReport);
+    if (m_SamplingReport->m_SelectedSortedCallstackReport)
+    {
+        ui->NextCallstackButton->setEnabled(true);
+        ui->PreviousCallstackButton->setEnabled(true);
+    }
     std::wstring label = m_SamplingReport->GetSelectedCallstackString();
     ui->CallStackLabel->setText( QString::fromStdWString(label) );
     ui->CallstackTreeView->Refresh();

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -13,7 +13,7 @@ OrbitSamplingReport::OrbitSamplingReport(QWidget *parent) : QWidget(parent)
                                                           , ui(new Ui::OrbitSamplingReport)
 {
     ui->setupUi(this);
-    if (!m_SamplingReport || !m_SamplingReport->m_SelectedSortedCallstackReport)
+    if (!m_SamplingReport || !m_SamplingReport->HasCallstacks())
     {
         ui->NextCallstackButton->setEnabled(false);
         ui->NextCallstackButton->setStyleSheet(QString::fromUtf8("QPushButton:disabled{ color: gray }"));
@@ -88,7 +88,7 @@ void OrbitSamplingReport::on_PreviousCallstackButton_clicked()
 void OrbitSamplingReport::Refresh()
 {
     assert(m_SamplingReport);
-    if (m_SamplingReport->m_SelectedSortedCallstackReport)
+    if (m_SamplingReport->HasCallstacks())
     {
         ui->NextCallstackButton->setEnabled(true);
         ui->PreviousCallstackButton->setEnabled(true);

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -64,6 +64,7 @@ void OrbitSamplingReport::Initialize( std::shared_ptr<SamplingReport> a_Report )
 //-----------------------------------------------------------------------------
 void OrbitSamplingReport::on_NextCallstackButton_clicked()
 {
+    assert(m_SamplingReport);
     m_SamplingReport->IncrementCallstackIndex();
     Refresh();
 }
@@ -71,6 +72,7 @@ void OrbitSamplingReport::on_NextCallstackButton_clicked()
 //-----------------------------------------------------------------------------
 void OrbitSamplingReport::on_PreviousCallstackButton_clicked()
 {
+    assert(m_SamplingReport);
     m_SamplingReport->DecrementCallstackIndex();
     Refresh();
 }
@@ -78,6 +80,7 @@ void OrbitSamplingReport::on_PreviousCallstackButton_clicked()
 //-----------------------------------------------------------------------------
 void OrbitSamplingReport::Refresh()
 {
+    assert(m_SamplingReport);
     std::wstring label = m_SamplingReport->GetSelectedCallstackString();
     ui->CallStackLabel->setText( QString::fromStdWString(label) );
     ui->CallstackTreeView->Refresh();


### PR DESCRIPTION
Disables the call stack navigation buttons, if either there is no capture yet, or if no symbols are selected for which the call stacks should be shown.
This fixes #42 