### PR TITLE
fixes #44: Do not try to load debug symbols when selecting a process

### DIFF
--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -52,8 +52,7 @@ bool Module::IsDll() const
 //-----------------------------------------------------------------------------
 bool Module::LoadDebugInfo()
 {
-    std::wstring pdbName = s2ws(m_PdbName);
-    m_Pdb = std::make_shared<Pdb>( pdbName.c_str() );
+    assert(m_Pdb);
     m_Pdb->SetMainModule( (HMODULE)m_AddressStart );
 
     PRINT_VAR(m_FoundPdb);

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -120,7 +120,12 @@ void Process::ListModules()
         std::shared_ptr<Module> & module = pair.second;
         std::string name = ToLower( module->m_Name );
         m_NameToModuleMap[name] = module;
-        module->LoadDebugInfo();
+        #ifdef _WIND32
+            // TODO: check if the windows implementation does something meaningfull
+            module->LoadDebugInfo();
+        #else
+            module->m_Pdb = std::make_shared<Pdb>();
+        #endif
     }
 }
 

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -120,7 +120,7 @@ void Process::ListModules()
         std::shared_ptr<Module> & module = pair.second;
         std::string name = ToLower( module->m_Name );
         m_NameToModuleMap[name] = module;
-        #ifdef _WIND32
+        #ifdef _WIN32
             // TODO: check if the windows implementation does something meaningfull
             module->LoadDebugInfo();
         #else

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -29,7 +29,6 @@
 
 std::shared_ptr<Pdb> GPdbDbg;
 
-// TODO: As there is an implementation in the header, this will never called.
 //-----------------------------------------------------------------------------
 Pdb::Pdb( const wchar_t* a_PdbName ) : m_FileName( a_PdbName )
                                      , m_MainModule(0)

--- a/OrbitCore/Pdb.cpp
+++ b/OrbitCore/Pdb.cpp
@@ -29,6 +29,7 @@
 
 std::shared_ptr<Pdb> GPdbDbg;
 
+// TODO: As there is an implementation in the header, this will never called.
 //-----------------------------------------------------------------------------
 Pdb::Pdb( const wchar_t* a_PdbName ) : m_FileName( a_PdbName )
                                      , m_MainModule(0)

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -132,8 +132,10 @@ protected:
 class Pdb
 {
 public:
+    //TODO: these constructors seem to be not usefull
     Pdb( const wchar_t* a_PdbName ){}
     Pdb( const char* a_PdbName){}
+    Pdb(){}
     ~Pdb(){}
 
     void Init(){}


### PR DESCRIPTION
This will also speed up listing the modules of a process.