### PR TITLE
added missing include

### DIFF
--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -8,6 +8,8 @@
 #include "ui_orbitsamplingreport.h"
 #include "../OrbitGl/SamplingReport.h"
 
+#include <cassert>
+
 //-----------------------------------------------------------------------------
 OrbitSamplingReport::OrbitSamplingReport(QWidget *parent) : QWidget(parent)
                                                           , ui(new Ui::OrbitSamplingReport)


### PR DESCRIPTION
This fixes a compilation error that was introduced with #52 on some environments, where assertions were not available.