### PR TITLE
Fixes #45: Stop Capturing on Exit

### DIFF
--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -539,6 +539,9 @@ void OrbitApp::SetLicense( const std::wstring & a_License )
 //-----------------------------------------------------------------------------
 int OrbitApp::OnExit()
 {
+    if( GTimerManager->m_IsRecording )
+        GOrbitApp->StopCapture();
+
     GParams.Save();
     delete GOrbitApp;
 	GTimerManager = nullptr;

--- a/OrbitQt/orbitsamplingreport.cpp
+++ b/OrbitQt/orbitsamplingreport.cpp
@@ -8,6 +8,8 @@
 #include "ui_orbitsamplingreport.h"
 #include "../OrbitGl/SamplingReport.h"
 
+#include <cassert>
+
 //-----------------------------------------------------------------------------
 OrbitSamplingReport::OrbitSamplingReport(QWidget *parent) : QWidget(parent)
                                                           , ui(new Ui::OrbitSamplingReport)


### PR DESCRIPTION
If you try to close Orbit while capturing, it will now stop the capturing beforehand.