### PR TITLE
Add elapsed time ellipsis printing to Capture View

### DIFF
--- a/OrbitGl/TextBox.cpp
+++ b/OrbitGl/TextBox.cpp
@@ -15,6 +15,7 @@ TextBox::TextBox() : m_Pos( Vec2::Zero() )
                    , m_MainFrameCounter( -1 )
                    , m_Selected( false )
                    , m_TextY( FLT_MAX )
+                   , m_ElapsedTimeTextLength( 0 )
 {
     Update();
 }
@@ -31,6 +32,7 @@ TextBox::TextBox( const Vec2 & a_Pos
                 , m_Color( a_Color )
                 , m_MainFrameCounter( -1 )
                 , m_Selected( false )
+                , m_ElapsedTimeTextLength( 0 )
 {
     Update();
 }
@@ -45,6 +47,7 @@ TextBox::TextBox( const Vec2 & a_Pos
                 , m_Color( a_Color )
                 , m_MainFrameCounter( -1 )
                 , m_Selected( false )
+                , m_ElapsedTimeTextLength( 0 )
 {
     Update();
 }
@@ -56,6 +59,7 @@ TextBox::TextBox( const Vec2 & a_Pos
                 , m_Size( a_Size )
                 , m_MainFrameCounter( -1 )
                 , m_Selected( false )
+                , m_ElapsedTimeTextLength( 0 )
 {
     Update();
 }

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -67,8 +67,8 @@ public:
 
     void SetTextY( float a_Y ){ m_TextY = a_Y; }
 
-    void SetElapsedTimeTextLength( const size_t& a_Length ){ m_ElapsedTimeTextLength = a_Length; }
-    const size_t GetElapsedTimeTextLength() const { return m_ElapsedTimeTextLength; }
+    void SetElapsedTimeTextLength( size_t a_Length ){ m_ElapsedTimeTextLength = a_Length; }
+    size_t GetElapsedTimeTextLength() const { return m_ElapsedTimeTextLength; }
 
     inline void SetColor( Color & a_Color ) { m_Color = a_Color; }
     inline void SetColor( UCHAR a_R, UCHAR a_G, UCHAR a_B ){ m_Color[0] = a_R; m_Color[1] = a_G; m_Color[2] = a_B; }

--- a/OrbitGl/TextBox.h
+++ b/OrbitGl/TextBox.h
@@ -67,6 +67,9 @@ public:
 
     void SetTextY( float a_Y ){ m_TextY = a_Y; }
 
+    void SetElapsedTimeTextLength( const size_t& a_Length ){ m_ElapsedTimeTextLength = a_Length; }
+    const size_t GetElapsedTimeTextLength() const { return m_ElapsedTimeTextLength; }
+
     inline void SetColor( Color & a_Color ) { m_Color = a_Color; }
     inline void SetColor( UCHAR a_R, UCHAR a_G, UCHAR a_B ){ m_Color[0] = a_R; m_Color[1] = a_G; m_Color[2] = a_B; }
     inline Color GetColor() { return m_Color; }
@@ -94,8 +97,9 @@ protected:
     Color        m_Color;
     Timer        m_Timer;
     int          m_MainFrameCounter;
-    bool		 m_Selected;
+    bool         m_Selected;
     float        m_TextY;
+    size_t       m_ElapsedTimeTextLength;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/TextRenderer.cpp
+++ b/OrbitGl/TextRenderer.cpp
@@ -271,12 +271,12 @@ void TextRenderer::AddText( const char* a_Text
 }
 
 //-----------------------------------------------------------------------------
-void TextRenderer::AddTextTrailingTimePrioritized( const char* a_Text
+void TextRenderer::AddTextTrailingCharsPrioritized( const char* a_Text
                                    , float a_X
                                    , float a_Y
                                    , float a_Z
                                    , const Color& a_Color
-                                   , size_t timeStringLength
+                                   , size_t a_TrailingCharsLength
                                    , float a_MaxSize )
 {
     float tempPenX = ToScreenSpace( a_X );
@@ -329,7 +329,7 @@ void TextRenderer::AddTextTrailingTimePrioritized( const char* a_Text
     static const size_t LEADING_CHARS_COUNT = 1;
     static const size_t ELLIPSIS_BUFFER_SIZE = ELLIPSIS_TEXT_LEN + LEADING_CHARS_COUNT;
 
-    bool useEllipsisText = (fittingCharsCount < textLen) && (fittingCharsCount > (timeStringLength + ELLIPSIS_BUFFER_SIZE));
+    bool useEllipsisText = (fittingCharsCount < textLen) && (fittingCharsCount > (a_TrailingCharsLength + ELLIPSIS_BUFFER_SIZE));
     
     if (!useEllipsisText)
     {
@@ -337,13 +337,13 @@ void TextRenderer::AddTextTrailingTimePrioritized( const char* a_Text
     }
     else
     {
-        auto leadingCharCount = fittingCharsCount - (timeStringLength + ELLIPSIS_TEXT_LEN);
+        auto leadingCharCount = fittingCharsCount - (a_TrailingCharsLength + ELLIPSIS_TEXT_LEN);
 
         std::string modifiedText(a_Text, leadingCharCount);
         modifiedText.append( ELLIPSIS_TEXT );
 
-        auto timePosition = textLen - timeStringLength;
-        modifiedText.append( &a_Text[timePosition], timeStringLength );
+        auto timePosition = textLen - a_TrailingCharsLength;
+        modifiedText.append( &a_Text[timePosition], a_TrailingCharsLength );
 
         AddText( modifiedText.c_str(), a_X, a_Y, a_Z, a_Color, a_MaxSize );
     }

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -25,6 +25,7 @@ public:
     void Init();
     void Display();
     void AddText( const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color, float a_MaxSize = -1.f, bool a_RightJustified = false );
+    void AddTextTrailingTimePrioritized( const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color, size_t timeStringLength, float a_MaxSize );
     int AddText2D( const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color, float a_MaxSize = -1.f, bool a_RightJustified = false, bool a_InvertY = true );
     
     void GetStringSize( const char* a_Text, int & a_Width, int & a_Height );

--- a/OrbitGl/TextRenderer.h
+++ b/OrbitGl/TextRenderer.h
@@ -25,7 +25,7 @@ public:
     void Init();
     void Display();
     void AddText( const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color, float a_MaxSize = -1.f, bool a_RightJustified = false );
-    void AddTextTrailingTimePrioritized( const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color, size_t timeStringLength, float a_MaxSize );
+    void AddTextTrailingCharsPrioritized( const char* a_Text, float a_X, float a_Y, float a_Z, const Color& a_Color, size_t a_TrailingCharsLength, float a_MaxSize );
     int AddText2D( const char* a_Text, int a_X, int a_Y, float a_Z, const Color& a_Color, float a_MaxSize = -1.f, bool a_RightJustified = false, bool a_InvertY = true );
     
     void GetStringSize( const char* a_Text, int & a_Width, int & a_Height );

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -643,7 +643,7 @@ void TimeGraph::UpdatePrimitives( bool a_Picking )
                             const Vec2 & boxSize = textBox.GetSize();
                             float posX = std::max(boxPos[0], minX);
                             float maxSize = boxPos[0] + boxSize[0] - posX;
-                            m_TextRendererStatic.AddTextTrailingTimePrioritized(textBox.GetText().c_str()
+                            m_TextRendererStatic.AddTextTrailingCharsPrioritized(textBox.GetText().c_str()
                                 , posX
                                 , textBox.GetPosY() + 1.f
                                 , GlCanvas::Z_VALUE_TEXT

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -605,6 +605,8 @@ void TimeGraph::UpdatePrimitives( bool a_Picking )
                             std::string time = GetPrettyTime(elapsedMillis);
                             Function* func = Capture::GSelectedFunctionsMap[timer.m_FunctionAddress];
 
+                            textBox.SetElapsedTimeTextLength(time.length());
+
                             const char* name = nullptr;
                             if (func)
                             {
@@ -641,11 +643,12 @@ void TimeGraph::UpdatePrimitives( bool a_Picking )
                             const Vec2 & boxSize = textBox.GetSize();
                             float posX = std::max(boxPos[0], minX);
                             float maxSize = boxPos[0] + boxSize[0] - posX;
-                            m_TextRendererStatic.AddText(textBox.GetText().c_str()
+                            m_TextRendererStatic.AddTextTrailingTimePrioritized(textBox.GetText().c_str()
                                 , posX
                                 , textBox.GetPosY() + 1.f
                                 , GlCanvas::Z_VALUE_TEXT
                                 , s_Color
+                                , textBox.GetElapsedTimeTextLength()
                                 , maxSize);
                         }
                     }


### PR DESCRIPTION
For instrumented timers, sometimes, the function names are quite long, and require a very high zoom level in order to print out the function name + elapsed time.

Because viewing the elapsed time is important, this change adds the ability to prioritize printing the elapsed time with this format:

Function name: "LONG TEXT CUT OFF HERE"
Elapsed time: 4.0 us 
Old:   ["LONG TEXT CUT OFF H"]
New: ["LONG TEXT CU... 4.0 us"]