### PR TITLE
Added a first prototype of perf live mode

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -42,6 +42,7 @@ set(HEADERS
     Hashing.h
     Injection.h
     LinuxPerf.h
+    LinuxPerfData.h
     Log.h
     LogInterface.h
     MemoryTracker.h
@@ -102,6 +103,7 @@ set(SOURCES
     FunctionStats.cpp
     Injection.cpp
     LinuxPerf.cpp
+    LinuxPerfData.cpp
     Log.cpp
     LogInterface.cpp
     MemoryTracker.cpp

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -200,6 +200,13 @@ bool Capture::StartCapture()
         GEventTracer.Start(GTargetProcess->GetID());
 #endif
     }
+    else if ( Capture::IsRemote() )
+    {
+        LinuxPerf perf(0);
+        Capture::NewSamplingProfiler();
+        Capture::GSamplingProfiler->StartCapture();
+        Capture::GSamplingProfiler->SetIsLinuxPerf(true);
+    }
 
     GCoreApp->SendToUiNow( L"startcapture" );
     
@@ -217,6 +224,12 @@ void Capture::StopCapture()
     if( IsTrackingEvents() )
     {
         GEventTracer.Stop();
+    }
+    else if ( Capture::IsRemote() )
+    {        
+        Capture::GSamplingProfiler->StopCapture();
+        Capture::GSamplingProfiler->ProcessSamples();
+        GCoreApp->RefreshCaptureView();
     }
 
     if (!GInjected)

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -204,8 +204,8 @@ bool Capture::StartCapture()
     {
         LinuxPerf perf(0);
         Capture::NewSamplingProfiler();
-        Capture::GSamplingProfiler->StartCapture();
         Capture::GSamplingProfiler->SetIsLinuxPerf(true);
+        Capture::GSamplingProfiler->StartCapture();
     }
 
     GCoreApp->SendToUiNow( L"startcapture" );

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -12,6 +12,7 @@
 #include "EventBuffer.h"
 #include "ProcessUtils.h"
 #include "LinuxPerf.h"
+#include "LinuxPerfData.h"
 #include "SamplingProfiler.h"
 #include "CoreApp.h"
 #include "OrbitModule.h"
@@ -161,6 +162,18 @@ void ConnectionManager::SetupClientCallbacks()
         Capture::GSamplingProfiler->StopCapture();
         Capture::GSamplingProfiler->ProcessSamples();
         GCoreApp->RefreshCaptureView();
+    } );
+
+    GTcpClient->AddMainThreadCallback ( Msg_SamplingCallstack, [=]( const Message& a_Msg )
+    {
+        // TODO: Send buffered callstacks.
+        LinuxPerfData data;
+
+        std::istringstream buffer(std::string(a_Msg.m_Data, a_Msg.m_Size));
+        cereal::JSONInputArchive inputAr(buffer);
+        inputAr(data);
+
+        GCoreApp->ProcessSamplingCallStack(&data);
     } );
 
     

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -164,7 +164,7 @@ void ConnectionManager::SetupClientCallbacks()
         GCoreApp->RefreshCaptureView();
     } );
 
-    GTcpClient->AddMainThreadCallback ( Msg_SamplingCallstack, [=]( const Message& a_Msg )
+    GTcpClient->AddCallback ( Msg_SamplingCallstack, [=]( const Message& a_Msg )
     {
         // TODO: Send buffered callstacks.
         LinuxPerfData data;

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -173,7 +173,7 @@ void ConnectionManager::SetupClientCallbacks()
         cereal::JSONInputArchive inputAr(buffer);
         inputAr(data);
 
-        GCoreApp->ProcessSamplingCallStack(&data);
+        GCoreApp->ProcessSamplingCallStack(data);
     } );
 
     

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -10,6 +10,7 @@
 #include "BaseTypes.h"
 
 class Timer;
+class LinuxPerfData;
 
 class CoreApp
 {
@@ -25,6 +26,7 @@ public:
     virtual void UpdateVariable( class Variable * /*a_Variable*/ ){}
     virtual void Disassemble( const std::string & /*a_FunctionName*/, DWORD64 /*a_VirtualAddress*/, const char * /*a_MachineCode*/, size_t /*a_Size*/ ){}
     virtual void ProcessTimer( Timer* /*a_Timer*/, const std::string& /*a_FunctionName*/ ) {}
+    virtual void ProcessSamplingCallStack(LinuxPerfData* /*a_CS*/) {}
     virtual const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >* GetRules(){ return nullptr; }
     virtual void SendRemoteProcess(uint32_t a_PID) {}
     virtual void RefreshCaptureView() {}

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -26,7 +26,7 @@ public:
     virtual void UpdateVariable( class Variable * /*a_Variable*/ ){}
     virtual void Disassemble( const std::string & /*a_FunctionName*/, DWORD64 /*a_VirtualAddress*/, const char * /*a_MachineCode*/, size_t /*a_Size*/ ){}
     virtual void ProcessTimer( Timer* /*a_Timer*/, const std::string& /*a_FunctionName*/ ) {}
-    virtual void ProcessSamplingCallStack(LinuxPerfData* /*a_CS*/) {}
+    virtual void ProcessSamplingCallStack(LinuxPerfData& /*a_CS*/) {}
     virtual const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >* GetRules(){ return nullptr; }
     virtual void SendRemoteProcess(uint32_t a_PID) {}
     virtual void RefreshCaptureView() {}

--- a/OrbitCore/LinuxPerf.cpp
+++ b/OrbitCore/LinuxPerf.cpp
@@ -10,6 +10,7 @@
 #include "PrintVar.h"
 #include "Capture.h"
 #include "Callstack.h"
+#include "CoreApp.h"
 #include "SamplingProfiler.h"
 #include "EventBuffer.h"
 #include "Capture.h"
@@ -47,8 +48,11 @@ LinuxPerf::LinuxPerf( uint32_t a_PID, uint32_t a_Freq )
         : m_PID(a_PID)
         , m_Frequency(a_Freq)
 {
-    m_OutputFile = "/tmp/perf.data";
-    m_ReportFile = Replace(m_OutputFile, ".data", ".txt");
+    m_Callback = [this](const std::string& a_Buffer)
+    {
+        HandleLine( a_Buffer );
+    };
+    m_PerfCommand = Format("perf record -k monotonic -F %u -p %u -g --no-buffering -o - | perf script -i -", m_Frequency, m_PID);
 }
 
 //-----------------------------------------------------------------------------
@@ -56,27 +60,18 @@ void LinuxPerf::Start()
 {
     PRINT_FUNC;
 #if __linux__
-    m_IsRunning = true;
+    m_ExitRequested = false;
 
-    std::string path = ws2s(Path::GetBasePath());
+    m_PerfData.Clear();
 
-    pid_t PID = fork();
-    if(PID == 0) {
-        execl   ( "/usr/bin/perf"
-                , "/usr/bin/perf"
-                , "record"
-                , "-k", "monotonic"
-                , "-F", Format("%u", m_Frequency).c_str()
-                , "-p", Format("%u", m_PID).c_str()
-                , "-g"
-                , "-o", m_OutputFile.c_str(), (const char*)nullptr);
-        exit(1);
-    }
-    else
-    {
-        m_ForkedPID = PID;
-        PRINT_VAR(m_ForkedPID);
-    }
+    m_Thread = std::make_shared<std::thread>
+        ( &LinuxUtils::StreamCommandOutput
+        , m_PerfCommand.c_str()
+        , m_Callback
+        , &m_ExitRequested
+        );
+    
+    m_Thread->detach();
 #endif
 }
 
@@ -85,35 +80,7 @@ void LinuxPerf::Stop()
 {
     PRINT_FUNC;
 #if __linux__
-    if( m_ForkedPID != 0 )
-    {
-        kill(m_ForkedPID, 15);
-        int status = 0;
-        waitpid(m_ForkedPID, &status, 0);
-    }
-
-    m_IsRunning = false;
-
-    //m_Thread = std::make_shared<std::thread>([this]{
-    std::string cmd = Format("perf script -i %s > %s", m_OutputFile.c_str(), m_ReportFile.c_str());
-    PRINT_VAR(cmd);
-    LinuxUtils::ExecuteCommand(cmd.c_str());
-
-    if( ConnectionManager::Get().IsRemote() )
-    {
-        std::ifstream t(m_ReportFile);
-        std::stringstream buffer;
-        buffer << t.rdbuf();
-        std::string perfData = buffer.str();
-        GTcpServer->Send(Msg_RemotePerf, (void*)perfData.data(), perfData.size());
-    }
-    //else
-    {
-        LoadPerfData(m_ReportFile);
-    }
-    // });
-
-    // m_Thread->detach();
+    m_ExitRequested = true;
 #endif
 }
 
@@ -140,96 +107,78 @@ bool ParseStackLine( const std::string& a_Line, uint64_t& o_Address, std::string
     return true;
 }
 
-//-----------------------------------------------------------------------------
-void LinuxPerf::LoadPerfData( const std::string& a_FileName )
+void LinuxPerf::HandleLine( const std::string& a_Line )
 {
-    SCOPE_TIMER_LOG(L"LoadPerfData");
-    std::ifstream inFile(a_FileName);
-    if( inFile.fail() )
-    {
-        PRINT_VAR("Could not open input file");
-        PRINT_VAR(a_FileName);
-        return;
-    }
+    std::cout << a_Line;
+    bool isEmptyLine = (a_Line.empty() || a_Line == "\n");
+    bool isHeader = !isEmptyLine && !StartsWith(a_Line, "\t");
+    bool isStackLine = !isHeader && !isEmptyLine;
+    bool isEndBlock = !isStackLine && isEmptyLine && !m_PerfData.m_header.empty();
 
-    LoadPerfData(inFile);
-    inFile.close();
+    if(isHeader)
+    {
+        m_PerfData.m_header = a_Line;
+        auto tokens = Tokenize(a_Line);
+        m_PerfData.m_time = tokens.size() > 2 ? GetMicros(tokens[2])*1000 : 0;
+        m_PerfData.m_tid  = tokens.size() > 1 ? atoi(tokens[1].c_str()) : 0;
+    }
+    else if(isStackLine)
+    {
+        std::string module;
+        std::string function;
+        uint64_t    address;
+
+        if( !ParseStackLine( a_Line, address, function, module ) )
+        {
+            PRINT_VAR("ParseStackLine error");
+            PRINT_VAR(a_Line);
+            return;
+        }
+
+        std::wstring moduleName = ToLower(Path::GetFileName(s2ws(module)));
+        std::shared_ptr<Module> moduleFromName = Capture::GTargetProcess->GetModuleFromName( ws2s(moduleName) );
+
+        if( moduleFromName )
+        {
+            uint64_t new_address = moduleFromName->ValidateAddress(address);
+
+            address = new_address;
+        }
+
+        m_PerfData.m_CS.m_Data.push_back(address);
+
+        if( Capture::GTargetProcess && !Capture::GTargetProcess->HasSymbol(address))
+        {
+            auto symbol = std::make_shared<LinuxSymbol>();
+            symbol->m_Name = function;
+            symbol->m_Module = module;
+            Capture::GTargetProcess->AddSymbol( address, symbol );
+        }
+    }
+    else if(isEndBlock)
+    {
+        if( m_PerfData.m_CS.m_Data.size() )
+        {
+            m_PerfData.m_CS.m_Depth = (uint32_t)m_PerfData.m_CS.m_Data.size();
+            m_PerfData.m_CS.m_ThreadId = m_PerfData.m_tid;
+            GCoreApp->ProcessSamplingCallStack(&m_PerfData);
+            ++m_PerfData.m_numCallstacks;
+        }
+
+        m_PerfData.Clear();
+    }
 }
 
 //-----------------------------------------------------------------------------
 void LinuxPerf::LoadPerfData( std::istream& a_Stream )
 {
-    std::string header;
-    uint32_t tid = 0;
-    uint64_t time = 0;
-    uint64_t numCallstacks = 0;
-
-    CallStack CS;
+    m_PerfData.Clear();
 
     for (std::string line; std::getline(a_Stream, line); )
     {
-        bool isHeader = !line.empty() && !StartsWith(line, "\t");
-        bool isStackLine = !isHeader && !line.empty();
-        bool isEndBlock = !isStackLine && line.empty() && !header.empty();
-
-        if(isHeader)
-        {
-            header = line;
-            auto tokens = Tokenize(line);
-            time = tokens.size() > 2 ? GetMicros(tokens[2])*1000 : 0;
-            tid  = tokens.size() > 1 ? atoi(tokens[1].c_str()) : 0;
-        }
-        else if(isStackLine)
-        {
-            std::string module;
-            std::string function;
-            uint64_t    address;
-
-            if( !ParseStackLine( line, address, function, module ) )
-            {
-                PRINT_VAR("ParseStackLine error");
-                PRINT_VAR(line);
-                continue;
-            }
-
-            std::wstring moduleName = ToLower(Path::GetFileName(s2ws(module)));
-            std::shared_ptr<Module> moduleFromName = Capture::GTargetProcess->GetModuleFromName( ws2s(moduleName) );
-
-            if( moduleFromName )
-            {
-                uint64_t new_address = moduleFromName->ValidateAddress(address);
-
-                address = new_address;
-            }
-
-            CS.m_Data.push_back(address);
-
-            if( Capture::GTargetProcess && !Capture::GTargetProcess->HasSymbol(address))
-            {
-                auto symbol = std::make_shared<LinuxSymbol>();
-                symbol->m_Name = function;
-                symbol->m_Module = module;
-                Capture::GTargetProcess->AddSymbol( address, symbol );
-            }
-        }
-        else if(isEndBlock)
-        {
-            if( CS.m_Data.size() )
-            {
-                CS.m_Depth = (uint32_t)CS.m_Data.size();
-                CS.m_ThreadId = tid;
-                Capture::GSamplingProfiler->AddCallStack( CS );
-                GEventTracer.GetEventBuffer().AddCallstackEvent( time, CS );
-                ++numCallstacks;
-            }
-
-            CS.m_Data.clear();
-            header = "";
-            time = 0;
-            tid = 0;
-        }
+        HandleLine(line);
     }
 
-    PRINT_VAR(numCallstacks);
+    PRINT_VAR(m_PerfData.m_numCallstacks);
     PRINT_FUNC;
 }

--- a/OrbitCore/LinuxPerf.cpp
+++ b/OrbitCore/LinuxPerf.cpp
@@ -109,7 +109,6 @@ bool ParseStackLine( const std::string& a_Line, uint64_t& o_Address, std::string
 
 void LinuxPerf::HandleLine( const std::string& a_Line )
 {
-    std::cout << a_Line;
     bool isEmptyLine = (a_Line.empty() || a_Line == "\n");
     bool isHeader = !isEmptyLine && !StartsWith(a_Line, "\t");
     bool isStackLine = !isHeader && !isEmptyLine;
@@ -161,7 +160,7 @@ void LinuxPerf::HandleLine( const std::string& a_Line )
         {
             m_PerfData.m_CS.m_Depth = (uint32_t)m_PerfData.m_CS.m_Data.size();
             m_PerfData.m_CS.m_ThreadId = m_PerfData.m_tid;
-            GCoreApp->ProcessSamplingCallStack(&m_PerfData);
+            GCoreApp->ProcessSamplingCallStack(m_PerfData);
             ++m_PerfData.m_numCallstacks;
         }
 

--- a/OrbitCore/LinuxPerf.h
+++ b/OrbitCore/LinuxPerf.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "BaseTypes.h"
+#include "LinuxPerfData.h"
 #include <string>
 #include <memory>
 #include <vector>
@@ -16,18 +17,22 @@ public:
     LinuxPerf(uint32_t a_PID, uint32_t a_Freq = 1000);
     void Start();
     void Stop();
-    bool IsRunning() const { return m_IsRunning; }
-    void LoadPerfData( const std::string& a_FileName );
+    bool IsRunning() const { return !m_ExitRequested; }
     void LoadPerfData( std::istream& a_Stream );
+    void HandleLine( const std::string& a_Line );
 
 private:
-    std::shared_ptr<std::thread> m_Thread;
-    bool m_IsRunning = false;
     uint32_t m_PID = 0;
     uint32_t m_ForkedPID = 0;
     uint32_t m_Frequency = 1000;
-    std::string m_OutputFile;
-    std::string m_ReportFile;
+
+    std::shared_ptr<std::thread> m_Thread;
+    bool m_ExitRequested = true;
+
+    std::function<void(const std::string& a_Data)> m_Callback;
+    std::string m_PerfCommand;
+
+    LinuxPerfData m_PerfData;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/LinuxPerfData.cpp
+++ b/OrbitCore/LinuxPerfData.cpp
@@ -1,0 +1,22 @@
+#include "LinuxPerfData.h"
+#include "SerializationMacros.h"
+#include "Serialization.h"
+
+
+void LinuxPerfData::Clear()
+{
+    m_CS.m_Data.clear();
+    m_header = "";
+    m_time = 0;
+    m_tid = 0;
+    m_numCallstacks = 0;
+}
+
+ORBIT_SERIALIZE( LinuxPerfData, 0 )
+{
+    ORBIT_NVP_VAL( 0, m_header );
+    ORBIT_NVP_VAL( 0, m_tid );
+    ORBIT_NVP_VAL( 0, m_time );
+    ORBIT_NVP_VAL( 0, m_numCallstacks );
+    ORBIT_NVP_VAL( 0, m_CS );
+}

--- a/OrbitCore/LinuxPerfData.h
+++ b/OrbitCore/LinuxPerfData.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Callstack.h"
+#include "SerializationMacros.h"
+
+#include <string>
+
+//-----------------------------------------------------------------------------
+class LinuxPerfData
+{
+public:
+    std::string m_header = "";
+    uint32_t m_tid = 0;
+    uint64_t m_time = 0;
+    uint64_t m_numCallstacks = 0;
+
+    CallStack m_CS;
+
+    void Clear();
+
+    ORBIT_SERIALIZABLE;
+};

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -40,6 +40,9 @@ enum MessageType : int16_t
     Msg_NumFlushedItems,
     Msg_NumInstalledHooks,
     Msg_Callstack,
+    // TODO: this should basically be the same.
+    Msg_SamplingCallstack,
+    Msg_TimerCallstack,
     Msg_OrbitZoneName,
     Msg_OrbitLog,
     Msg_WaitLoop,

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -39,10 +39,8 @@ enum MessageType : int16_t
     Msg_NumFlushedEntries,
     Msg_NumFlushedItems,
     Msg_NumInstalledHooks,
+    // TODO: This should not be needed in the future.
     Msg_Callstack,
-    // TODO: this should basically be the same.
-    Msg_SamplingCallstack,
-    Msg_TimerCallstack,
     Msg_OrbitZoneName,
     Msg_OrbitLog,
     Msg_WaitLoop,
@@ -63,6 +61,8 @@ enum MessageType : int16_t
     Msg_RemoteModuleDebugInfo,
     Msg_BpfScript,
     Msg_RemoteTimers,
+    Msg_SamplingCallstack,
+    Msg_TimerCallstack,
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -139,6 +139,15 @@ void SamplingProfiler::FireDoneProcessingCallbacks()
 }
 
 //-----------------------------------------------------------------------------
+void SamplingProfiler::AddCallStack( CallStack & a_CallStack ) {
+    if( m_State == Sampling )
+    {
+        ScopeLock lock(m_SymbolMutex);
+        m_Callstacks.push_back( a_CallStack );
+    }
+}
+
+//-----------------------------------------------------------------------------
 std::multimap<int, CallstackID> SamplingProfiler::GetCallStacksFromAddress( uint64_t a_Addr, ThreadID a_TID, int & o_NumCallstacks )
 {
     std::set<CallstackID> & callstacks = m_FunctionToCallstacks[a_Addr];

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -95,7 +95,7 @@ public:
     float GetSampleTimeTotal() const { return m_SampleTimeSeconds; }
     bool  ShouldStop();
     void FireDoneProcessingCallbacks();
-    void AddCallStack( CallStack & a_CallStack ) { if( m_State == Sampling ) m_Callstacks.push_back( a_CallStack ); }
+    void AddCallStack( CallStack & a_CallStack );
     const std::shared_ptr<CallStack> GetCallStack( CallstackID a_ID ) { return m_UniqueCallstacks[a_ID]; }
     std::multimap<int, CallstackID> GetCallStacksFromAddress( uint64_t a_Addr, ThreadID a_TID, int & o_NumCallstacks );
     std::shared_ptr< SortedCallstackReport > GetSortedCallstacksFromAddress( uint64_t a_Addr, ThreadID a_TID );

--- a/OrbitCore/TcpEntity.h
+++ b/OrbitCore/TcpEntity.h
@@ -66,7 +66,7 @@ public:
     inline void Send(const std::string& a_String);
     inline void Send(OrbitLogEntry& a_Entry);
     inline void Send(Orbit::UserData& a_Entry);
-    inline void Send(MessageType a_Type , void* a_Data, size_t a_Size);
+    inline void Send(MessageType a_Type , const void* a_Data, size_t a_Size);
 
     template<class T> void Send( Message & a_Message, const std::vector<T> & a_Vector );
     template<class T> void Send( MessageType a_Type , const std::vector<T> & a_Vector );
@@ -199,7 +199,7 @@ template<class T> void TcpEntity::Send( MessageType a_Type, const T& a_Item )
 }
 
 //-----------------------------------------------------------------------------
-void TcpEntity::Send( MessageType a_Type , void* a_Data, size_t a_Size )
+void TcpEntity::Send( MessageType a_Type , const void* a_Data, size_t a_Size )
 {
     Message msg(a_Type);
     msg.m_Size = (uint32_t)a_Size;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -28,9 +28,12 @@
 #include "CaptureSerializer.h"
 #include "PluginManager.h"
 #include "RuleEditor.h"
+#include "LinuxPerfData.h"
 
 #include "OrbitAsm/OrbitAsm.h"
 #include "OrbitCore/Pdb.h"
+#include "OrbitCore/Capture.h"
+#include "OrbitCore/SamplingProfiler.h"
 #include "OrbitCore/ModuleManager.h"
 #include "OrbitCore/TcpServer.h"
 #include "OrbitCore/TcpClient.h"
@@ -185,6 +188,22 @@ void OrbitApp::ProcessTimer( Timer* a_Timer, const std::string& a_FunctionName )
     {
         GCurrentTimeGraph->ProcessTimer(*a_Timer);
         ++Capture::GFunctionCountMap[a_Timer->m_FunctionAddress];
+    }
+}
+
+// TODO: This method should try to send the callstack hashes only.
+//-----------------------------------------------------------------------------
+void OrbitApp::ProcessSamplingCallStack(LinuxPerfData* a_CallStack)
+{
+    if (ConnectionManager::Get().IsRemote())
+    {
+        std::string messageData = SerializeObjectHumanReadable(*a_CallStack);
+        GTcpServer->Send(Msg_SamplingCallstack, messageData.c_str(), messageData.size());
+    }
+    else
+    {
+        Capture::GSamplingProfiler->AddCallStack( a_CallStack->m_CS );
+        GEventTracer.GetEventBuffer().AddCallstackEvent( a_CallStack->m_time, a_CallStack->m_CS );
     }
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -193,17 +193,17 @@ void OrbitApp::ProcessTimer( Timer* a_Timer, const std::string& a_FunctionName )
 
 // TODO: This method should try to send the callstack hashes only.
 //-----------------------------------------------------------------------------
-void OrbitApp::ProcessSamplingCallStack(LinuxPerfData* a_CallStack)
+void OrbitApp::ProcessSamplingCallStack(LinuxPerfData& a_CallStack)
 {
     if (ConnectionManager::Get().IsRemote())
     {
-        std::string messageData = SerializeObjectHumanReadable(*a_CallStack);
+        std::string messageData = SerializeObjectHumanReadable(a_CallStack);
         GTcpServer->Send(Msg_SamplingCallstack, messageData.c_str(), messageData.size());
     }
     else
     {
-        Capture::GSamplingProfiler->AddCallStack( a_CallStack->m_CS );
-        GEventTracer.GetEventBuffer().AddCallstackEvent( a_CallStack->m_time, a_CallStack->m_CS );
+        Capture::GSamplingProfiler->AddCallStack( a_CallStack.m_CS );
+        GEventTracer.GetEventBuffer().AddCallstackEvent( a_CallStack.m_time, a_CallStack.m_CS );
     }
 }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -69,7 +69,7 @@ public:
     void RefreshWatch();
     virtual void Disassemble( const std::string & a_FunctionName, DWORD64 a_VirtualAddress, const char * a_MachineCode, size_t a_Size );
     virtual void ProcessTimer( Timer* a_Timer, const std::string& a_FunctionName );
-    virtual void ProcessSamplingCallStack(LinuxPerfData* a_CallStack);
+    virtual void ProcessSamplingCallStack(LinuxPerfData& a_CallStack);
 
     int* GetScreenRes() { return m_ScreenRes; }
 

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -69,6 +69,7 @@ public:
     void RefreshWatch();
     virtual void Disassemble( const std::string & a_FunctionName, DWORD64 a_VirtualAddress, const char * a_MachineCode, size_t a_Size );
     virtual void ProcessTimer( Timer* a_Timer, const std::string& a_FunctionName );
+    virtual void ProcessSamplingCallStack(LinuxPerfData* a_CallStack);
 
     int* GetScreenRes() { return m_ScreenRes; }
 


### PR DESCRIPTION
Fixes #59 by introducing live sampling.
Right now, for each sampling event, the callstack will be send as a tcp message.
We could omit this by only sending the hash instead, however this requires some more refactoring of the SamplingProfiler class.
I would add this in a different PR.

**Also, this PR requires PR#71 to be merged, as this introduces sending symbols.**