### PR TITLE
Removed debug output, to save several seconds when loading symbols.

### DIFF
--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -178,7 +178,6 @@ bool Pdb::LoadPdb( const wchar_t* a_PdbName )
                     {
                         std::string probe = tokens[1];
                         func->m_Probe = probe;
-                        PRINT_VAR(func->m_Probe);
                     }
                 }
             }


### PR DESCRIPTION
For large binaries (~100mb), printing all functions took about 10 seconds.
As loading the hookable functions is now stable, this output should not be needed anymore.