### PR TITLE
synchronized selected functions map

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -26,6 +26,7 @@
 #include "TestRemoteMessages.h"
 #include <fstream>
 #include <ostream>
+#include <cereal/types/vector.hpp>
 
 #ifdef _WIN32
 #include "EventTracer.h"
@@ -333,6 +334,17 @@ void Capture::SendFunctionHooks()
 
     if (Capture::IsRemote())
     {
+        std::vector<std::string> selectedFunctions;
+        for (auto pair : GSelectedFunctionsMap)
+        {
+            PRINT(Format("Send Selected Function: %s\n", pair.second->m_PrettyName.c_str()));
+            selectedFunctions.push_back(std::to_string(pair.first));
+        }
+
+        std::string selectedFunctionsData = SerializeObjectHumanReadable(selectedFunctions);
+        PRINT_VAR(selectedFunctionsData);
+        GTcpClient->Send(Msg_RemoteSelectedFunctionsMap, (void*)selectedFunctionsData.data(), selectedFunctionsData.size());
+
         BpfTrace bpfTrace;
         PRINT_VAR(bpfTrace.GetBpfScript());
         GTcpClient->Send(Msg_BpfScript, bpfTrace.GetBpfScript());

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -24,9 +24,10 @@
 #include "OrbitRule.h"
 #include "CoreApp.h"
 #include "TestRemoteMessages.h"
+#include "Serialization.h"
+
 #include <fstream>
 #include <ostream>
-#include <cereal/types/vector.hpp>
 
 #ifdef _WIN32
 #include "EventTracer.h"
@@ -335,9 +336,9 @@ void Capture::SendFunctionHooks()
     if (Capture::IsRemote())
     {
         std::vector<std::string> selectedFunctions;
-        for (auto pair : GSelectedFunctionsMap)
+        for (auto& pair : GSelectedFunctionsMap)
         {
-            PRINT(Format("Send Selected Function: %s\n", pair.second->m_PrettyName.c_str()));
+            PRINT("Send Selected Function: %s\n", pair.second->m_PrettyName.c_str());
             selectedFunctions.push_back(std::to_string(pair.first));
         }
 

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -17,6 +17,7 @@
 #include "OrbitModule.h"
 #include "OrbitFunction.h"
 #include "BpfTrace.h"
+#include "Serialization.h"
 
 #if __linux__
 #include "LinuxUtils.h"
@@ -26,7 +27,6 @@
 #include <streambuf>
 #include <sstream>
 #include <iostream>
-#include <cereal/types/vector.hpp>
 
 //-----------------------------------------------------------------------------
 ConnectionManager::ConnectionManager() : m_ExitRequested(false), m_IsRemote(false)
@@ -76,25 +76,35 @@ void ConnectionManager::InitAsRemote()
 }
 
 //-----------------------------------------------------------------------------
-void ConnectionManager::SetSelectedFunctionsOnRemote( const char* a_Data, size_t a_Size ) {
+void ConnectionManager::SetSelectedFunctionsOnRemote( const Message & a_Msg ) {
     PRINT_FUNC;
+    const char* a_Data = a_Msg.GetData();
+     size_t a_Size = a_Msg.m_Size;
     std::istringstream buffer(std::string(a_Data, a_Size));
     cereal::JSONInputArchive inputAr( buffer );
     std::vector<std::string> selectedFunctions;
     inputAr(selectedFunctions);
 
+    // Unselect the all currently selected functions:
+    std::vector<Function*> prevSelectedFuncs;
+    for (auto& pair : Capture::GSelectedFunctionsMap)
+    {
+        prevSelectedFuncs.push_back(pair.second);
+    }
+
     Capture::GSelectedFunctionsMap.clear();
-    for (Function* function : Capture::GTargetProcess->GetFunctions()) {
+    for (Function* function : prevSelectedFuncs) {
         function->UnSelect();
     }
 
+    // Select the received functions:
     for (const std::string& address : selectedFunctions) {
         PRINT_VAR(address);
         Function* function = Capture::GTargetProcess->GetFunctionFromAddress(std::stoll(address));
         if (!function)
             PRINT("received invalid address");
         else{
-            PRINT(Format("Received Selected Function: %s\n", function->m_PrettyName.c_str()));
+            PRINT("Received Selected Function: %s\n", function->m_PrettyName.c_str());
             // this also adds the function to the map.
             function->Select();
         }
@@ -134,7 +144,7 @@ void ConnectionManager::SetupServerCallbacks()
 
     GTcpServer->AddMainThreadCallback( Msg_RemoteSelectedFunctionsMap, [=]( const Message & a_Msg )
     {
-        SetSelectedFunctionsOnRemote(a_Msg.GetData(), a_Msg.m_Size);
+        SetSelectedFunctionsOnRemote(a_Msg);
     } );
 
     GTcpServer->AddMainThreadCallback( Msg_StartCapture, [=]( const Message & a_Msg )

--- a/OrbitCore/ConnectionManager.h
+++ b/OrbitCore/ConnectionManager.h
@@ -19,7 +19,7 @@ public:
     void InitAsRemote();
     void ConnectToRemote(std::string a_RemoteAddress);
     bool IsRemote(){ return m_IsRemote; } // True when Orbit instance is headless, next to remote process
-    void SetSelectedFunctionsOnRemote(const char* a_Data, size_t a_Size );
+    void SetSelectedFunctionsOnRemote(const Message & a_Msg);
     void StartCaptureAsRemote();
     void StopCaptureAsRemote();
     void Stop();

--- a/OrbitCore/ConnectionManager.h
+++ b/OrbitCore/ConnectionManager.h
@@ -3,6 +3,8 @@
 //-----------------------------------
 #pragma once
 
+#include "Message.h"
+
 #include <string>
 #include <vector>
 #include <memory>

--- a/OrbitCore/ConnectionManager.h
+++ b/OrbitCore/ConnectionManager.h
@@ -19,6 +19,7 @@ public:
     void InitAsRemote();
     void ConnectToRemote(std::string a_RemoteAddress);
     bool IsRemote(){ return m_IsRemote; } // True when Orbit instance is headless, next to remote process
+    void SetSelectedFunctionsOnRemote(const char* a_Data, size_t a_Size );
     void StartCaptureAsRemote();
     void StopCaptureAsRemote();
     void Stop();

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -60,6 +60,7 @@ enum MessageType : int16_t
     Msg_RemoteModuleDebugInfo,
     Msg_BpfScript,
     Msg_RemoteTimers,
+    Msg_RemoteSelectedFunctionsMap,
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -15,6 +15,8 @@
 #include "SamplingProfiler.h"
 #include "Utils.h"
 
+#include <map>
+
 #ifdef _WIN32
 #include "OrbitDia.h"
 #include "SymbolUtils.h"
@@ -74,6 +76,21 @@ bool Function::Hookable()
         return ((conv == CV_CALL_NEAR_C || CV_CALL_THISCALL) && m_Size >= 5)
             || (GParams.m_AllowUnsafeHooking && m_Size == 0);
     }
+}
+
+void Function::Select()
+{ 
+    if( Hookable() )
+    {
+        m_Selected = true; 
+        Capture::GSelectedFunctionsMap[GetVirtualAddress()] = this;
+    }
+}
+
+void Function::UnSelect()
+{
+    m_Selected = false;
+    Capture::GSelectedFunctionsMap.erase(GetVirtualAddress());
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -71,9 +71,9 @@ public:
     bool IsMemberFunction();
     unsigned long long Hash() { if( m_NameHash == 0 ) { m_NameHash = StringHash( m_PrettyName ); } return m_NameHash; }
     bool Hookable();
-    void Select(){ if( Hookable() ) m_Selected = true; }
+    void Select();
     void PreHook();
-    void UnSelect(){ m_Selected = false; }
+    void UnSelect();
     void ToggleSelect() { /*if( Hookable() )*/ m_Selected = !m_Selected; }
     bool IsSelected() const { return m_Selected; }
     DWORD64 GetVirtualAddress() const;


### PR DESCRIPTION
That change will always synchronize the selected functions between remote and server before capturing. 
Also it ensures on the client side, that the GSelectedFunctionMap is always in synch. with the functions that are selected.
This in particular useful when later changing from Bpftrace to perf_event_open, or something where it does not make sense to simply send a script including the selected functions.
As the functions are not send one-by-one, the overhead should be fairly small. 