### PR TITLE
prepared sampling to only send callstacks once and hashes afterwards

### DIFF
--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -35,6 +35,7 @@ struct CallStack
     CallStack( CallStackPOD a_CS );
     inline CallstackID Hash() 
     { 
+        if (m_Hash != 0) return m_Hash;
         m_Hash = XXH64( m_Data.data(), m_Depth * sizeof( uint64_t ), 0xca1157ac );
         return m_Hash; 
     }
@@ -45,6 +46,16 @@ struct CallStack
     uint32_t    m_Depth = 0;
     ThreadID    m_ThreadId = 0;
     std::vector<uint64_t> m_Data;
+
+    ORBIT_SERIALIZABLE;
+};
+
+//-----------------------------------------------------------------------------
+struct HashedCallStack
+{
+    CallstackID m_Hash = 0;
+    uint32_t    m_Depth = 0;
+    ThreadID    m_ThreadId = 0;
 
     ORBIT_SERIALIZABLE;
 };

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -56,11 +56,11 @@ public:
     }
 
     //-----------------------------------------------------------------------------
-    void AddCallstackEvent( long long a_Time, CallStack & a_CallStack )
+    void AddCallstackEvent( long long a_Time, CallstackID a_CSHash, ThreadID a_TID )
     {
         ScopeLock lock( m_Mutex );
-        std::map< long long, CallstackEvent > & threadMap = m_CallstackEvents[ a_CallStack.m_ThreadId ];
-        threadMap[a_Time] = CallstackEvent( a_Time, a_CallStack.Hash(), a_CallStack.m_ThreadId );
+        std::map< long long, CallstackEvent > & threadMap = m_CallstackEvents[ a_TID ];
+        threadMap[a_Time] = CallstackEvent( a_Time, a_CSHash, a_TID );
         RegisterTime( a_Time );
     }
 

--- a/OrbitCore/LinuxPerf.cpp
+++ b/OrbitCore/LinuxPerf.cpp
@@ -218,8 +218,15 @@ void LinuxPerf::LoadPerfData( std::istream& a_Stream )
             {
                 CS.m_Depth = (uint32_t)CS.m_Data.size();
                 CS.m_ThreadId = tid;
-                Capture::GSamplingProfiler->AddCallStack( CS );
-                GEventTracer.GetEventBuffer().AddCallstackEvent( time, CS );
+                CallstackID hash = CS.Hash();
+
+                HashedCallStack hashedCallStack;
+                hashedCallStack.m_Depth = CS.m_Depth;
+                hashedCallStack.m_Hash = hash;
+                hashedCallStack.m_ThreadId = tid;
+
+                Capture::GSamplingProfiler->AddHashedCallStack( hashedCallStack );
+                GEventTracer.GetEventBuffer().AddCallstackEvent( time, hash, tid );
                 ++numCallstacks;
             }
 

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -100,7 +100,13 @@ public:
     void AddHashedCallStack( HashedCallStack & a_CallStack );
     void AddUniqueCallStack( CallStack & a_CallStack );
     const std::shared_ptr<CallStack> GetCallStack( CallstackID a_ID ) { return m_UniqueCallstacks[a_ID]; }
-    bool HasCallStack( CallstackID a_ID );
+    
+    inline bool HasCallStack( CallstackID a_ID )
+    {
+        auto it = m_UniqueCallstacks.find( a_ID ); 
+        return it != m_UniqueCallstacks.end();
+    }
+
     std::multimap<int, CallstackID> GetCallStacksFromAddress( uint64_t a_Addr, ThreadID a_TID, int & o_NumCallstacks );
     std::shared_ptr< SortedCallstackReport > GetSortedCallstacksFromAddress( uint64_t a_Addr, ThreadID a_TID );
     

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -95,8 +95,12 @@ public:
     float GetSampleTimeTotal() const { return m_SampleTimeSeconds; }
     bool  ShouldStop();
     void FireDoneProcessingCallbacks();
-    void AddCallStack( CallStack & a_CallStack ) { if( m_State == Sampling ) m_Callstacks.push_back( a_CallStack ); }
+    // TODO: remove this method in the future.
+    void AddCallStack( CallStack & a_CallStack );
+    void AddHashedCallStack( HashedCallStack & a_CallStack );
+    void AddUniqueCallStack( CallStack & a_CallStack );
     const std::shared_ptr<CallStack> GetCallStack( CallstackID a_ID ) { return m_UniqueCallstacks[a_ID]; }
+    bool HasCallStack( CallstackID a_ID );
     std::multimap<int, CallstackID> GetCallStacksFromAddress( uint64_t a_Addr, ThreadID a_TID, int & o_NumCallstacks );
     std::shared_ptr< SortedCallstackReport > GetSortedCallstacksFromAddress( uint64_t a_Addr, ThreadID a_TID );
     
@@ -135,19 +139,19 @@ protected:
     void OutputStats();
 
 protected:
-    std::shared_ptr<Process>        m_Process;
-    std::unique_ptr<std::thread>    m_SamplingThread;
-    std::atomic<SamplingState>      m_State;
-    BlockChain<CallStack, 16*1024 > m_Callstacks;
-    Timer                           m_SamplingTimer;
-    Timer                           m_ThreadUsageTimer;
-    int                             m_PeriodMs = 1;
-    float                           m_SampleTimeSeconds = FLT_MAX;
-    bool                            m_GenerateSummary = true;
-    Mutex                           m_SymbolMutex;
-    int                             m_NumSamples = 0;
-    bool                            m_LoadedFromFile = false;
-    bool                            m_IsLinuxPerf = false;
+    std::shared_ptr<Process>                m_Process;
+    std::unique_ptr<std::thread>            m_SamplingThread;
+    std::atomic<SamplingState>              m_State;
+    BlockChain<HashedCallStack, 16*1024 >   m_Callstacks;
+    Timer                                   m_SamplingTimer;
+    Timer                                   m_ThreadUsageTimer;
+    int                                     m_PeriodMs = 1;
+    float                                   m_SampleTimeSeconds = FLT_MAX;
+    bool                                    m_GenerateSummary = true;
+    Mutex                                   m_SymbolMutex;
+    int                                     m_NumSamples = 0;
+    bool                                    m_LoadedFromFile = false;
+    bool                                    m_IsLinuxPerf = false;
 
     std::unordered_map<ThreadID, ThreadSampleData>              m_ThreadSampleData;
     std::unordered_map<CallstackID, std::shared_ptr<CallStack>> m_UniqueCallstacks;


### PR DESCRIPTION
The SamplingProfiler now only stores the complete callstacks once per unique stack. The list of all callstacks (`m_Callstacks`) now does not contain the complete callstack data anymore. 

However, there were more callers to the `AddCallStack` method, so I decided to temporarily keep it.

Also the `EventBuffer::AddCallstackEvent` method does not take a callstack anymore.

With this, it will be quite simple to not send the complete callstacks on live mode anymore. 