### PR TITLE
Fixed two warnings

### DIFF
--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -71,7 +71,7 @@ bool Function::Hookable()
         }
 
         CV_call_e conv = (CV_call_e)m_CallConv;
-        return ((conv == CV_CALL_NEAR_C || CV_CALL_THISCALL) && m_Size >= 5)
+        return ((conv == CV_CALL_NEAR_C || conv == CV_CALL_THISCALL) && m_Size >= 5)
             || (GParams.m_AllowUnsafeHooking && m_Size == 0);
     }
 }

--- a/OrbitGl/CallStackDataView.cpp
+++ b/OrbitGl/CallStackDataView.cpp
@@ -119,7 +119,7 @@ Function & CallStackDataView::GetFunction( unsigned int a_Row )
 
     if( m_CallStack )
     {
-        if( (int)a_Row < m_CallStack->m_Depth )
+        if( a_Row < m_CallStack->m_Depth )
         {
             ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
 


### PR DESCRIPTION
There was a comparison of an signed and unsigned int as well as a check on a non-boolean value.