### PR TITLE
Also clear the scheduling info when clearing the TimeGraph.

### DIFF
--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -64,6 +64,9 @@ void TimeGraph::Clear()
 
     ScopeLock lock(m_Mutex);
     m_ThreadTracks.clear();
+
+    m_ContextSwitchesMap.clear();
+    m_CoreUtilizationMap.clear();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Otherwise, there the beginning of the scheduling data view might gets broken at the beginning when doing a second capture.