### PR TITLE
Implemented dynamic instrumentation using perf_event_open.

### DIFF
--- a/OrbitCore/BpfTrace.cpp
+++ b/OrbitCore/BpfTrace.cpp
@@ -357,6 +357,8 @@ void BpfTrace::RunPerfEventOpen(bool* a_ExitRequested)
             // read everything that is new
             while (ring_buffer.HasNewData() && i < ROUND_ROBIN_BATCH_SIZE)
             {
+                i++;
+                new_events = true;
                 perf_event_header header{};
                 ring_buffer.ReadHeader(&header);
 
@@ -402,6 +404,8 @@ void BpfTrace::RunPerfEventOpen(bool* a_ExitRequested)
             // read everything that is new
             while (ring_buffer.HasNewData() && i < ROUND_ROBIN_BATCH_SIZE)
             {
+                i++;
+                new_events = true;
                 perf_event_header header{};
                 ring_buffer.ReadHeader(&header);
 

--- a/OrbitCore/BpfTrace.h
+++ b/OrbitCore/BpfTrace.h
@@ -30,6 +30,7 @@ protected:
     void CommandCallback(const std::string& a_Line);
     void CommandCallbackWithCallstacks(const std::string& a_Line);
     bool WriteBpfScript();
+    static void RunPerfEventOpen(bool* a_ExitRequested);
 
 private:    
     std::map<std::string, std::vector<Timer>> m_TimerStacks;

--- a/OrbitCore/BpfTraceVisitor.cpp
+++ b/OrbitCore/BpfTraceVisitor.cpp
@@ -1,0 +1,41 @@
+#include "BpfTraceVisitor.h"
+#include "OrbitFunction.h"
+#include "CoreApp.h"
+
+void BpfTraceVisitor::visit(LinuxPerfLostEvent* a_Event)
+{
+    PRINT("Lost %u Events\n", a_Event->Lost());
+}
+
+void BpfTraceVisitor::visit(LinuxUprobeEvent* a_Event)
+{
+    Timer timer;
+    timer.m_TID = a_Event->TID();
+    timer.m_Start = a_Event->Timestamp();
+    timer.m_Depth = (uint8_t)m_TimerStacks[a_Event->TID()].size();
+    timer.m_FunctionAddress = a_Event->GetFunction()->GetVirtualAddress();
+    m_TimerStacks[a_Event->TID()].push_back(timer);
+}
+
+void BpfTraceVisitor::visit(LinuxUretprobeEvent* a_Event)
+{
+    std::vector<Timer>& timers = m_TimerStacks[a_Event->TID()];
+    if (timers.size())
+    {
+        Timer& timer = timers.back();
+        timer.m_End = a_Event->Timestamp();
+        GCoreApp->ProcessTimer(&timer, std::to_string(a_Event->GetFunction()->GetVirtualAddress()));
+        timers.pop_back();
+    }
+}
+
+// TODO: Here, we would also like to handle the callstack
+void BpfTraceVisitor::visit(LinuxUprobeEventWithStack* a_Event)
+{
+    Timer timer;
+    timer.m_TID = a_Event->TID();
+    timer.m_Start = a_Event->Timestamp();
+    timer.m_Depth = (uint8_t)m_TimerStacks[a_Event->TID()].size();
+    timer.m_FunctionAddress = a_Event->GetFunction()->GetVirtualAddress();
+    m_TimerStacks[a_Event->TID()].push_back(timer);
+}

--- a/OrbitCore/BpfTraceVisitor.h
+++ b/OrbitCore/BpfTraceVisitor.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "LinuxPerfEvent.h"
+#include "LinuxPerfEventVisitor.h"
+#include "ScopeTimer.h"
+
+class BpfTraceVisitor : public LinuxPerfEventVisitor
+{
+public:
+    void visit(LinuxPerfLostEvent* a_Event) override;
+    void visit(LinuxUprobeEvent* a_Event) override;
+    void visit(LinuxUprobeEventWithStack* a_Event) override;
+    void visit(LinuxUretprobeEvent* a_Event) override;
+
+private:
+    std::map<uint64_t, std::vector<Timer>> m_TimerStacks;
+};

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -194,6 +194,7 @@ endif()
 # Linux
 if(LINUX)
     set(PLATFORM_HEADERS 
+        BpfTraceVisitor.cpp
         LinuxUtils.h    
         LinuxPerfEvent.h
         LinuxPerfEventVisitor.h
@@ -204,6 +205,7 @@ if(LINUX)
         LinuxEventTracerVisitor.h
     )
     set(PLATFORM_SOURCES 
+        BpfTraceVisitor.cpp
         LinuxUtils.cpp
         LinuxPerfEvent.cpp
         LinuxPerfRingBuffer.cpp

--- a/OrbitCore/LinuxPerfEvent.cpp
+++ b/OrbitCore/LinuxPerfEvent.cpp
@@ -17,3 +17,12 @@ void LinuxForkEvent::accept(LinuxPerfEventVisitor* a_Visitor) { a_Visitor->visit
 
 //-----------------------------------------------------------------------------
 void LinuxSchedSwitchEvent::accept(LinuxPerfEventVisitor* a_Visitor) { a_Visitor->visit(this); }
+
+//-----------------------------------------------------------------------------
+void LinuxUprobeEvent::accept(LinuxPerfEventVisitor* a_Visitor) { a_Visitor->visit(this); }
+
+//-----------------------------------------------------------------------------
+void LinuxUprobeEventWithStack::accept(LinuxPerfEventVisitor* a_Visitor) { a_Visitor->visit(this); }
+
+//-----------------------------------------------------------------------------
+void LinuxUretprobeEvent::accept(LinuxPerfEventVisitor* a_Visitor) { a_Visitor->visit(this); }

--- a/OrbitCore/LinuxPerfEvent.h
+++ b/OrbitCore/LinuxPerfEvent.h
@@ -9,6 +9,7 @@
 
 #include "PrintVar.h"
 #include "LinuxPerfUtils.h"
+#include "OrbitFunction.h"
 
 using namespace LinuxPerfUtils;
 
@@ -130,4 +131,48 @@ public:
 
     uint32_t PrevTID() { return ring_buffer_data.trace_point.prev_pid; }
     uint32_t NextTID() { return ring_buffer_data.trace_point.next_pid; }
+};
+    
+
+
+template<typename perf_record_data_t>
+class AbstractLinuxUprobeEvent : public LinuxPerfEventRecord<perf_record_data_t>
+{
+public: 
+    Function* GetFunction() { return m_Function; }
+    void SetFunction(Function* a_Function) { m_Function = a_Function; }
+private: 
+    Function* m_Function = nullptr;
+};
+
+struct perf_empty_record
+{
+    struct perf_event_header header;
+    struct perf_sample_id basic_sample_data;
+};
+
+struct perf_record_with_stack
+{
+    struct perf_event_header header;
+    struct perf_sample_id basic_sample_data;
+    struct perf_sample_regs_user register_data;
+    struct perf_sample_stack_user stack_data;
+};
+
+class LinuxUprobeEvent : public AbstractLinuxUprobeEvent<perf_empty_record>
+{
+public:
+    void accept(LinuxPerfEventVisitor* a_Visitor) override;
+};
+
+class LinuxUprobeEventWithStack : public AbstractLinuxUprobeEvent<perf_record_with_stack>
+{
+public:
+    void accept(LinuxPerfEventVisitor* a_Visitor) override;
+};
+
+class LinuxUretprobeEvent : public AbstractLinuxUprobeEvent<perf_empty_record>
+{
+public:
+    void accept(LinuxPerfEventVisitor* a_Visitor) override;
 };

--- a/OrbitCore/LinuxPerfEventVisitor.h
+++ b/OrbitCore/LinuxPerfEventVisitor.h
@@ -14,7 +14,10 @@
 class LinuxPerfEventVisitor
 {
 public:
-    virtual void visit(LinuxPerfLostEvent* a_Event) = 0;
-    virtual void visit(LinuxForkEvent* a_Event) = 0;
-    virtual void visit(LinuxSchedSwitchEvent* a_Event) = 0;
+    virtual void visit(LinuxPerfLostEvent* a_Event) {};
+    virtual void visit(LinuxForkEvent* a_Event) {};
+    virtual void visit(LinuxSchedSwitchEvent* a_Event) {};
+    virtual void visit(LinuxUprobeEvent* a_Event) {};
+    virtual void visit(LinuxUprobeEventWithStack* a_Event) {};
+    virtual void visit(LinuxUretprobeEvent* a_Event) {};
 };

--- a/OrbitCore/LinuxPerfUtils.cpp
+++ b/OrbitCore/LinuxPerfUtils.cpp
@@ -72,3 +72,57 @@ int32_t LinuxPerfUtils::tracepoint_event_open(
 
     return fd;
 }
+
+//-----------------------------------------------------------------------------
+int32_t LinuxPerfUtils::uprobe_event_open(
+    const char* a_Module,
+    uint64_t a_FunctionOffset,
+    pid_t a_PID,
+    int32_t a_CPU,
+    uint64_t additonal_sample_type
+)
+{
+    perf_event_attr pe = generic_perf_event_attr();
+
+    pe.type = 7;
+    pe.config = 0;
+    pe.uprobe_path = reinterpret_cast<uint64_t>(a_Module);
+    pe.probe_offset = a_FunctionOffset;
+    pe.sample_type |= additonal_sample_type;
+
+    int32_t fd = perf_event_open(&pe, a_PID, a_CPU, -1 /*grpup_fd*/, 0 /*flags*/);
+
+    if (fd == -1)
+    {
+        PRINT("perf_event_open error: %d\n", errno);
+    }
+
+    return fd;
+}
+
+//-----------------------------------------------------------------------------
+int32_t LinuxPerfUtils::uretprobe_event_open(
+    const char* a_Module,
+    uint64_t a_FunctionOffset, 
+    pid_t a_PID,
+    int32_t a_CPU,
+    uint64_t additonal_sample_type
+)
+{
+    perf_event_attr pe = generic_perf_event_attr();
+
+    pe.type = 7;
+    pe.config = 1;
+    pe.uprobe_path = reinterpret_cast<uint64_t>(a_Module);
+    pe.probe_offset = a_FunctionOffset;
+    pe.sample_type |= additonal_sample_type;
+
+    int32_t fd = perf_event_open(&pe, a_PID, a_CPU, -1 /*grpup_fd*/, 0 /*flags*/);
+
+    if (fd == -1)
+    {
+        PRINT("perf_event_open error: %d\n", errno);
+    }
+
+    return fd;
+}

--- a/OrbitCore/LinuxPerfUtils.cpp
+++ b/OrbitCore/LinuxPerfUtils.cpp
@@ -10,6 +10,7 @@
 #include "LinuxPerfUtils.h"
 
 #include <linux/perf_event.h>
+#include <linux/version.h>
 #include <sys/errno.h>
 
 //-----------------------------------------------------------------------------
@@ -73,6 +74,7 @@ int32_t LinuxPerfUtils::tracepoint_event_open(
     return fd;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0)
 //-----------------------------------------------------------------------------
 int32_t LinuxPerfUtils::uprobe_event_open(
     const char* a_Module,
@@ -126,3 +128,4 @@ int32_t LinuxPerfUtils::uretprobe_event_open(
 
     return fd;
 }
+#endif

--- a/OrbitCore/LinuxPerfUtils.h
+++ b/OrbitCore/LinuxPerfUtils.h
@@ -10,6 +10,7 @@
 #include <asm/unistd.h>
 #include <asm/perf_regs.h>
 #include <linux/perf_event.h>
+#include <linux/version.h>
 #include <sys/errno.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -72,7 +73,9 @@ namespace LinuxPerfUtils
 
     int32_t tracepoint_event_open(uint64_t a_TracepointID, pid_t a_PID, int32_t a_CPU, uint64_t additonal_sample_type = 0);
 
-    int32_t uprobe_event_open(const char* a_Module, uint64_t a_FunctionOffset, pid_t a_PID, int32_t a_CPU, uint64_t additonal_sample_type = 0);
 
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0)
+    int32_t uprobe_event_open(const char* a_Module, uint64_t a_FunctionOffset, pid_t a_PID, int32_t a_CPU, uint64_t additonal_sample_type = 0);
     int32_t uretprobe_event_open(const char* a_Module, uint64_t a_FunctionOffset, pid_t a_PID, int32_t a_CPU, uint64_t additonal_sample_type = 0);
+    #endif
 }

--- a/OrbitCore/LinuxPerfUtils.h
+++ b/OrbitCore/LinuxPerfUtils.h
@@ -71,4 +71,8 @@ namespace LinuxPerfUtils
     int32_t task_event_open(int32_t a_CPU);
 
     int32_t tracepoint_event_open(uint64_t a_TracepointID, pid_t a_PID, int32_t a_CPU, uint64_t additonal_sample_type = 0);
+
+    int32_t uprobe_event_open(const char* a_Module, uint64_t a_FunctionOffset, pid_t a_PID, int32_t a_CPU, uint64_t additonal_sample_type = 0);
+
+    int32_t uretprobe_event_open(const char* a_Module, uint64_t a_FunctionOffset, pid_t a_PID, int32_t a_CPU, uint64_t additonal_sample_type = 0);
 }

--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -26,6 +26,7 @@ Params::Params() : m_LoadTypeInfo( true )
                  , m_AutoReleasePdb(false)
                  , m_BpftraceCallstacks(false)
                  , m_SystemWideScheduling(true)
+                 , m_UseBpftrace(false)
                  , m_MaxNumTimers( 1000000 )
                  , m_FontSize( 14.f )
                  , m_Port(44766)
@@ -34,7 +35,7 @@ Params::Params() : m_LoadTypeInfo( true )
 {
 }
 
-ORBIT_SERIALIZE( Params, 15 )
+ORBIT_SERIALIZE( Params, 16 )
 {
     ORBIT_NVP_VAL( 0, m_LoadTypeInfo );
     ORBIT_NVP_VAL( 0, m_SendCallStacks );
@@ -60,6 +61,7 @@ ORBIT_SERIALIZE( Params, 15 )
     ORBIT_NVP_VAL( 13, m_ProcessFilter );
     ORBIT_NVP_VAL( 14, m_BpftraceCallstacks );
     ORBIT_NVP_VAL( 15, m_SystemWideScheduling );
+    ORBIT_NVP_VAL( 16, m_UseBpftrace );
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Params.h
+++ b/OrbitCore/Params.h
@@ -31,6 +31,7 @@ public:
     bool  m_AutoReleasePdb;
     bool  m_BpftraceCallstacks;
     bool  m_SystemWideScheduling;
+    bool  m_UseBpftrace;
     int   m_MaxNumTimers;
     float m_FontSize;
     int   m_Port;


### PR DESCRIPTION
This PR adds an implementation of dynamic instrumentation using the perf_event_open syscall instead of invoking the bpftrace command line tool and parsing its output.

It currently has no support for callstacks, but, already has some internal preparation for this. Basically the unwinding part is missing completely.

Edit:
I just pushed a commit that removes the call to `bpftrace -l uprobe: ` and replaces it with a call to objdump and grep. This call is actually the fallback in bpftrace itself ([found here](https://github.com/iovisor/bpftrace/blob/52ff6e39bae4c89b23cf88084603a33e2abfb37c/src/bpftrace.cpp#L1647)).