### PR TITLE
Send context-switch information to remote & Batch multiple callstacks/timers into single messages.

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -41,8 +41,8 @@ set(HEADERS
     FunctionStats.h
     Hashing.h
     Injection.h
+    LinuxCallstackEvent.h
     LinuxPerf.h
-    LinuxPerfData.h
     Log.h
     LogInterface.h
     MemoryTracker.h
@@ -102,8 +102,8 @@ set(SOURCES
     EventBuffer.cpp
     FunctionStats.cpp
     Injection.cpp
+    LinuxCallstackEvent.cpp
     LinuxPerf.cpp
-    LinuxPerfData.cpp
     Log.cpp
     LogInterface.cpp
     MemoryTracker.cpp

--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -189,6 +189,5 @@ ORBIT_SERIALIZE( CallStack, 0 )
 ORBIT_SERIALIZE( HashedCallStack, 0 )
 {
     ORBIT_NVP_VAL( 0, m_Hash );
-    ORBIT_NVP_VAL( 0, m_Depth );
     ORBIT_NVP_VAL( 0, m_ThreadId );
 }

--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -184,3 +184,11 @@ ORBIT_SERIALIZE( CallStack, 0 )
     ORBIT_NVP_VAL( 0, m_Depth );
     ORBIT_NVP_VAL( 0, m_ThreadId );
 }
+
+//-----------------------------------------------------------------------------
+ORBIT_SERIALIZE( HashedCallStack, 0 )
+{
+    ORBIT_NVP_VAL( 0, m_Hash );
+    ORBIT_NVP_VAL( 0, m_Depth );
+    ORBIT_NVP_VAL( 0, m_ThreadId );
+}

--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -56,7 +56,6 @@ struct CallStack
 struct HashedCallStack
 {
     CallstackID m_Hash = 0;
-    uint32_t    m_Depth = 0;
     ThreadID    m_ThreadId = 0;
 
     ORBIT_SERIALIZABLE;

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -368,6 +368,7 @@ void Capture::SendFunctionHooks()
         GTcpClient->Send(Msg_StartCapture);
     }
     else
+        // TODO: Why is this? This seems to be unnecessary.
         GTcpServer->Send( Msg_StartCapture );
 
     // Unreal

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -12,7 +12,7 @@
 #include "EventBuffer.h"
 #include "ProcessUtils.h"
 #include "LinuxPerf.h"
-#include "LinuxPerfData.h"
+#include "LinuxCallstackEvent.h"
 #include "SamplingProfiler.h"
 #include "CoreApp.h"
 #include "OrbitModule.h"
@@ -214,7 +214,7 @@ void ConnectionManager::SetupClientCallbacks()
     GTcpClient->AddCallback ( Msg_SamplingCallstack, [=]( const Message& a_Msg )
     {
         // TODO: Send buffered callstacks.
-        LinuxPerfData data;
+        LinuxCallstackEvent data;
 
         std::istringstream buffer(std::string(a_Msg.m_Data, a_Msg.m_Size));
         cereal::JSONInputArchive inputAr(buffer);
@@ -270,7 +270,7 @@ void ConnectionManager::SetupClientCallbacks()
         size_t a_Size = a_Msg.m_Size;
         std::istringstream buffer(std::string(a_Data, a_Size));
         cereal::JSONInputArchive inputAr( buffer );
-        std::vector<LinuxPerfData> call_stacks;
+        std::vector<LinuxCallstackEvent> call_stacks;
         inputAr(call_stacks);
 
         for (auto& cs : call_stacks)
@@ -285,7 +285,7 @@ void ConnectionManager::SetupClientCallbacks()
         size_t a_Size = a_Msg.m_Size;
         std::istringstream buffer(std::string(a_Data, a_Size));
         cereal::JSONInputArchive inputAr( buffer );
-        std::vector<HashedLinuxPerfData> call_stacks;
+        std::vector<CallstackEvent> call_stacks;
         inputAr(call_stacks);
 
         for (auto& cs : call_stacks)

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -256,16 +256,11 @@ void ConnectionManager::SetupClientCallbacks()
 
     GTcpClient->AddCallback(Msg_RemoteContextSwitches, [=](const Message& a_Msg)
     {
-        const char* a_Data = a_Msg.GetData();
-        size_t a_Size = a_Msg.m_Size;
-        std::istringstream buffer(std::string(a_Data, a_Size));
-        cereal::JSONInputArchive inputAr( buffer );
-        std::vector<ContextSwitch> context_switches;
-        inputAr(context_switches);
-
-        for (const auto& cs : context_switches)
+        uint32_t num_context_switches = (uint32_t)a_Msg.m_Size / sizeof(ContextSwitch);
+        ContextSwitch* context_switches = (ContextSwitch*) a_Msg.GetData();
+        for (uint32_t i = 0; i < num_context_switches; i++)
         {
-            GCoreApp->ProcessContextSwitch(cs);
+            GCoreApp->ProcessContextSwitch(context_switches[i]);
         }
     } );
 

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -269,7 +269,7 @@ void ConnectionManager::SetupClientCallbacks()
         const char* a_Data = a_Msg.GetData();
         size_t a_Size = a_Msg.m_Size;
         std::istringstream buffer(std::string(a_Data, a_Size));
-        cereal::JSONInputArchive inputAr( buffer );
+        cereal::BinaryInputArchive inputAr( buffer );
         std::vector<LinuxCallstackEvent> call_stacks;
         inputAr(call_stacks);
 
@@ -284,7 +284,7 @@ void ConnectionManager::SetupClientCallbacks()
         const char* a_Data = a_Msg.GetData();
         size_t a_Size = a_Msg.m_Size;
         std::istringstream buffer(std::string(a_Data, a_Size));
-        cereal::JSONInputArchive inputAr( buffer );
+        cereal::BinaryInputArchive inputAr( buffer );
         std::vector<CallstackEvent> call_stacks;
         inputAr(call_stacks);
 

--- a/OrbitCore/ContextSwitch.cpp
+++ b/OrbitCore/ContextSwitch.cpp
@@ -3,6 +3,7 @@
 //-----------------------------------
 
 #include "ContextSwitch.h"
+#include "Serialization.h"
 
 //-----------------------------------------------------------------------------
 ContextSwitch::ContextSwitch( SwitchType a_Type ) : m_ThreadId( 0 )
@@ -18,4 +19,13 @@ ContextSwitch::ContextSwitch( SwitchType a_Type ) : m_ThreadId( 0 )
 ContextSwitch::~ContextSwitch()
 {
 
+}
+
+ORBIT_SERIALIZE( ContextSwitch, 0 )
+{
+    ORBIT_NVP_VAL( 0, m_ThreadId );
+    ORBIT_NVP_VAL( 0, m_Type );
+    ORBIT_NVP_VAL( 0, m_Time );
+    ORBIT_NVP_VAL( 0, m_ProcessorIndex );
+    ORBIT_NVP_VAL( 0, m_ProcessorNumber );
 }

--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -3,6 +3,8 @@
 //-----------------------------------
 #pragma once
 
+#include "Serialization.h"
+
 //-----------------------------------------------------------------------------
 struct ContextSwitch
 {
@@ -11,9 +13,11 @@ public:
     ContextSwitch( SwitchType a_Type = Invalid );
     ~ContextSwitch();
 
-    unsigned int    m_ThreadId;
-    SwitchType      m_Type;
-    long long       m_Time;
-    unsigned short  m_ProcessorIndex;
-    unsigned char   m_ProcessorNumber;
+    uint32_t    m_ThreadId;
+    SwitchType  m_Type;
+    uint64_t    m_Time;
+    uint16_t    m_ProcessorIndex;
+    uint8_t     m_ProcessorNumber;
+
+    ORBIT_SERIALIZABLE;
 };

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -12,6 +12,8 @@
 class Timer;
 class LinuxPerfData;
 struct CallStack;
+struct ContextSwitch;
+struct HashedLinuxPerfData;
 
 class CoreApp
 {
@@ -28,11 +30,16 @@ public:
     virtual void Disassemble( const std::string & /*a_FunctionName*/, DWORD64 /*a_VirtualAddress*/, const char * /*a_MachineCode*/, size_t /*a_Size*/ ){}
     virtual void ProcessTimer( Timer* /*a_Timer*/, const std::string& /*a_FunctionName*/ ) {}
     virtual void ProcessSamplingCallStack(LinuxPerfData& /*a_CS*/) {}
+    virtual void ProcessHashedSamplingCallStack(HashedLinuxPerfData& /*a_CallStack*/) {}
     virtual void ProcessCallStack( CallStack& /*a_CallStack*/ ){}
+    virtual void ProcessContextSwitch( const ContextSwitch& /*a_ContextSwithc*/ ){}
     virtual void AddSymbol(uint64_t /*a_Address*/, const std::string& /*a_Module*/, const std::string& /*a_Name*/){}
     virtual const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >* GetRules(){ return nullptr; }
     virtual void SendRemoteProcess(uint32_t a_PID) {}
     virtual void RefreshCaptureView() {}
+
+    virtual void StartRemoteCaptureBufferingThread(){}
+    virtual void StopRemoteCaptureBufferingThread(){}
 
     std::vector< std::wstring > m_SymbolLocations;
 };

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -10,10 +10,10 @@
 #include "BaseTypes.h"
 
 class Timer;
-class LinuxPerfData;
+class LinuxCallstackEvent;
 struct CallStack;
 struct ContextSwitch;
-struct HashedLinuxPerfData;
+struct CallstackEvent;
 
 class CoreApp
 {
@@ -29,10 +29,10 @@ public:
     virtual void UpdateVariable( class Variable * /*a_Variable*/ ){}
     virtual void Disassemble( const std::string & /*a_FunctionName*/, DWORD64 /*a_VirtualAddress*/, const char * /*a_MachineCode*/, size_t /*a_Size*/ ){}
     virtual void ProcessTimer( Timer* /*a_Timer*/, const std::string& /*a_FunctionName*/ ) {}
-    virtual void ProcessSamplingCallStack(LinuxPerfData& /*a_CS*/) {}
-    virtual void ProcessHashedSamplingCallStack(HashedLinuxPerfData& /*a_CallStack*/) {}
+    virtual void ProcessSamplingCallStack(LinuxCallstackEvent& /*a_CS*/) {}
+    virtual void ProcessHashedSamplingCallStack(CallstackEvent& /*a_CallStack*/) {}
     virtual void ProcessCallStack( CallStack& /*a_CallStack*/ ){}
-    virtual void ProcessContextSwitch( const ContextSwitch& /*a_ContextSwithc*/ ){}
+    virtual void ProcessContextSwitch( const ContextSwitch& /*a_ContextSwitch*/ ){}
     virtual void AddSymbol(uint64_t /*a_Address*/, const std::string& /*a_Module*/, const std::string& /*a_Name*/){}
     virtual const std::unordered_map<DWORD64, std::shared_ptr<class Rule> >* GetRules(){ return nullptr; }
     virtual void SendRemoteProcess(uint32_t a_PID) {}

--- a/OrbitCore/LinuxCallstackEvent.cpp
+++ b/OrbitCore/LinuxCallstackEvent.cpp
@@ -5,33 +5,25 @@
 //-----------------------------------
 // Author: Florian Kuebler
 //-----------------------------------
-#include "LinuxPerfData.h"
+#include "LinuxCallstackEvent.h"
 #include "SerializationMacros.h"
 #include "Serialization.h"
 
 
-void LinuxPerfData::Clear()
+void LinuxCallstackEvent::Clear()
 {
     m_CS.m_Data.clear();
     m_CS.m_Hash = 0;
+    m_CS.m_ThreadId = 0;
     m_header = "";
     m_time = 0;
-    m_tid = 0;
     m_numCallstacks = 0;
 }
 
-ORBIT_SERIALIZE( LinuxPerfData, 0 )
+ORBIT_SERIALIZE( LinuxCallstackEvent, 0 )
 {
     ORBIT_NVP_VAL( 0, m_header );
-    ORBIT_NVP_VAL( 0, m_tid );
     ORBIT_NVP_VAL( 0, m_time );
     ORBIT_NVP_VAL( 0, m_numCallstacks );
-    ORBIT_NVP_VAL( 0, m_CS );
-}
-
-
-ORBIT_SERIALIZE( HashedLinuxPerfData, 0 )
-{
-    ORBIT_NVP_VAL( 0, m_time );
     ORBIT_NVP_VAL( 0, m_CS );
 }

--- a/OrbitCore/LinuxCallstackEvent.h
+++ b/OrbitCore/LinuxCallstackEvent.h
@@ -13,28 +13,16 @@
 #include <string>
 
 //-----------------------------------------------------------------------------
-class LinuxPerfData
+class LinuxCallstackEvent
 {
 public:
     std::string m_header = "";
-    uint32_t m_tid = 0; // TODO: This is actually redundant
     uint64_t m_time = 0;
     uint64_t m_numCallstacks = 0;
 
     CallStack m_CS;
 
     void Clear();
-
-    ORBIT_SERIALIZABLE;
-};
-
-//-----------------------------------------------------------------------------
-struct HashedLinuxPerfData
-{
-public:
-    uint64_t m_time = 0;
-
-    HashedCallStack m_CS;
 
     ORBIT_SERIALIZABLE;
 };

--- a/OrbitCore/LinuxEventTracer.cpp
+++ b/OrbitCore/LinuxEventTracer.cpp
@@ -20,7 +20,7 @@
 #include "Params.h"
 #include "TimerManager.h"
 #include "ContextSwitch.h"
-#include "ConnectionManager.h"
+#include "CoreApp.h"
 
 #include <vector>
 
@@ -32,12 +32,9 @@ void LinuxEventTracer::Start()
 #if __linux__
     m_ExitRequested = false;
 
-    // TODO: DISABLE REMOTE SCHEDULER INFORMATION TRACING UNTIL WE ACTUALLY SEND THE EVENTS.
-    if ( !ConnectionManager::Get().IsService() )
-    {
-        m_Thread = std::make_shared<std::thread>(&LinuxEventTracer::Run, &m_ExitRequested);
-        m_Thread->detach();
-    }
+    m_Thread = std::make_shared<std::thread>(&LinuxEventTracer::Run, &m_ExitRequested);
+    m_Thread->detach();
+
 #endif
 }
 
@@ -150,7 +147,7 @@ void LinuxEventTracer::Run(bool* a_ExitRequested)
                                 CS.m_ProcessorIndex = sched_switch.CPU();
                                 //TODO: Is this correct?
                                 CS.m_ProcessorNumber = sched_switch.CPU();
-                                GTimerManager->Add( CS );
+                                GCoreApp->ProcessContextSwitch( CS );
                             }
 
                             // record start of excetion
@@ -164,7 +161,7 @@ void LinuxEventTracer::Run(bool* a_ExitRequested)
                                 CS.m_ProcessorIndex = sched_switch.CPU();
                                 //TODO: Is this correct?
                                 CS.m_ProcessorNumber = sched_switch.CPU();
-                                GTimerManager->Add( CS );
+                                GCoreApp->ProcessContextSwitch( CS );
                             }
                         }
                         else

--- a/OrbitCore/LinuxEventTracerVisitor.cpp
+++ b/OrbitCore/LinuxEventTracerVisitor.cpp
@@ -11,6 +11,7 @@
 #include "LinuxEventTracerVisitor.h"
 #include "LinuxPerfEvent.h"
 #include "PrintVar.h"
+#include "CoreApp.h"
 
 void LinuxEventTracerVisitor::visit(LinuxPerfLostEvent* a_Event)
 {
@@ -38,7 +39,7 @@ void LinuxEventTracerVisitor::visit(LinuxSchedSwitchEvent* a_Event)
         CS.m_ProcessorIndex = a_Event->CPU();
         //TODO: Is this correct?
         CS.m_ProcessorNumber = a_Event->CPU();
-        GTimerManager->Add( CS );
+        GCoreApp->ProcessContextSwitch( CS );
     }
 
     // the known thread starts running
@@ -52,6 +53,6 @@ void LinuxEventTracerVisitor::visit(LinuxSchedSwitchEvent* a_Event)
         CS.m_ProcessorIndex = a_Event->CPU();
         //TODO: Is this correct?
         CS.m_ProcessorNumber = a_Event->CPU();
-        GTimerManager->Add( CS );
+        GCoreApp->ProcessContextSwitch( CS );
     }
 }

--- a/OrbitCore/LinuxPerf.cpp
+++ b/OrbitCore/LinuxPerf.cpp
@@ -155,7 +155,6 @@ void LinuxPerf::HandleLine( const std::string& a_Line )
         if( CS.m_Data.size() )
         {
             CS.m_Depth = (uint32_t)CS.m_Data.size();
-            CallstackID hash = CS.Hash();
 
             GCoreApp->ProcessSamplingCallStack(m_PerfData);
             ++m_PerfData.m_numCallstacks;

--- a/OrbitCore/LinuxPerf.cpp
+++ b/OrbitCore/LinuxPerf.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <fstream>
 
-#include "LinuxUtils.h"
+#include "LinuxCallstackEvent.h"
 #include "Utils.h"
 #include "PrintVar.h"
 #include "Capture.h"
@@ -119,7 +119,7 @@ void LinuxPerf::HandleLine( const std::string& a_Line )
         m_PerfData.m_header = a_Line;
         auto tokens = Tokenize(a_Line);
         m_PerfData.m_time = tokens.size() > 2 ? GetMicros(tokens[2])*1000 : 0;
-        m_PerfData.m_tid  = tokens.size() > 1 ? atoi(tokens[1].c_str()) : 0;
+        m_PerfData.m_CS.m_ThreadId = tokens.size() > 1 ? atoi(tokens[1].c_str()) : 0;
     }
     else if(isStackLine)
     {
@@ -155,14 +155,10 @@ void LinuxPerf::HandleLine( const std::string& a_Line )
         if( CS.m_Data.size() )
         {
             CS.m_Depth = (uint32_t)CS.m_Data.size();
-            CS.m_ThreadId = m_PerfData.m_tid;
             CallstackID hash = CS.Hash();
 
             GCoreApp->ProcessSamplingCallStack(m_PerfData);
             ++m_PerfData.m_numCallstacks;
-
-            Capture::GSamplingProfiler->AddCallStack( CS );
-            GEventTracer.GetEventBuffer().AddCallstackEvent( m_PerfData.m_time, hash, m_PerfData.m_tid );
         }
 
         m_PerfData.Clear();

--- a/OrbitCore/LinuxPerf.h
+++ b/OrbitCore/LinuxPerf.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "BaseTypes.h"
-#include "LinuxPerfData.h"
+#include "LinuxCallstackEvent.h"
 #include "SerializationMacros.h"
 #include "Serialization.h"
 #include <string>
@@ -34,7 +34,7 @@ private:
     std::function<void(const std::string& a_Data)> m_Callback;
     std::string m_PerfCommand;
 
-    LinuxPerfData m_PerfData;
+    LinuxCallstackEvent m_PerfData;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/LinuxPerfData.cpp
+++ b/OrbitCore/LinuxPerfData.cpp
@@ -28,3 +28,10 @@ ORBIT_SERIALIZE( LinuxPerfData, 0 )
     ORBIT_NVP_VAL( 0, m_numCallstacks );
     ORBIT_NVP_VAL( 0, m_CS );
 }
+
+
+ORBIT_SERIALIZE( HashedLinuxPerfData, 0 )
+{
+    ORBIT_NVP_VAL( 0, m_time );
+    ORBIT_NVP_VAL( 0, m_CS );
+}

--- a/OrbitCore/LinuxPerfData.h
+++ b/OrbitCore/LinuxPerfData.h
@@ -17,13 +17,24 @@ class LinuxPerfData
 {
 public:
     std::string m_header = "";
-    uint32_t m_tid = 0;
+    uint32_t m_tid = 0; // TODO: This is actually redundant
     uint64_t m_time = 0;
     uint64_t m_numCallstacks = 0;
 
     CallStack m_CS;
 
     void Clear();
+
+    ORBIT_SERIALIZABLE;
+};
+
+//-----------------------------------------------------------------------------
+struct HashedLinuxPerfData
+{
+public:
+    uint64_t m_time = 0;
+
+    HashedCallStack m_CS;
 
     ORBIT_SERIALIZABLE;
 };

--- a/OrbitCore/Message.h
+++ b/OrbitCore/Message.h
@@ -66,6 +66,9 @@ enum MessageType : int16_t
     Msg_SamplingCallstack,
     Msg_TimerCallstack,
     Msg_RemoteSelectedFunctionsMap,
+    Msg_RemoteContextSwitches,
+    Msg_SamplingCallstacks,
+    Msg_SamplingHashedCallstacks,
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/SamplingProfiler.h
+++ b/OrbitCore/SamplingProfiler.h
@@ -8,6 +8,7 @@
 #include "Callstack.h"
 #include "BlockChain.h"
 #include "SerializationMacros.h"
+#include "EventBuffer.h"
 
 class Process;
 class Thread;
@@ -97,7 +98,7 @@ public:
     void FireDoneProcessingCallbacks();
 
     void AddCallStack( CallStack & a_CallStack );
-    void AddHashedCallStack( HashedCallStack & a_CallStack );
+    void AddHashedCallStack( CallstackEvent & a_CallStack );
     void AddUniqueCallStack( CallStack & a_CallStack );
   
     const std::shared_ptr<CallStack> GetCallStack( CallstackID a_ID )
@@ -154,7 +155,7 @@ protected:
     std::shared_ptr<Process>                m_Process;
     std::unique_ptr<std::thread>            m_SamplingThread;
     std::atomic<SamplingState>              m_State;
-    BlockChain<HashedCallStack, 16*1024 >   m_Callstacks;
+    BlockChain<CallstackEvent, 16*1024 >    m_Callstacks;
     Timer                                   m_SamplingTimer;
     Timer                                   m_ThreadUsageTimer;
     int                                     m_PeriodMs = 1;

--- a/OrbitCore/Serialization.h
+++ b/OrbitCore/Serialization.h
@@ -88,6 +88,17 @@ template <class T> inline std::string SerializeObjectHumanReadable(T& a_Object)
     return ss.str();
 }
 
+//-----------------------------------------------------------------------------
+template <class T> inline std::string SerializeObjectBinary(T& a_Object)
+{
+    std::stringstream ss;
+    {
+        cereal::BinaryOutputArchive archive(ss);
+        archive(a_Object);
+    }
+    return ss.str();
+}
+
 #define ORBIT_SIZE_SCOPE( x ) ScopeCounter counter( x )
 
 #define ORBIT_NVP( v, x ) if( a_Version >= v ) a_Archive( cereal::make_nvp( #x, p.x ) )

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -181,8 +181,11 @@ void GLoadPdbAsync( const std::vector<std::wstring> & a_Modules )
 void OrbitApp::StartRemoteCaptureBufferingThread()
 {
     PRINT_FUNC;
+    m_TimerBuffer.clear();
+    m_SamplingCallstackBuffer.clear();
+    m_HashedSamplingCallstackBuffer.clear();
+    m_ContextSwitchBuffer.clear();
     m_MessageBufferThread = std::make_shared<std::thread>(&OrbitApp::ProcessBufferedCaptureData, this);
-    m_MessageBufferThread->detach();
 }
 
 //-----------------------------------------------------------------------------
@@ -191,6 +194,7 @@ void OrbitApp::StopRemoteCaptureBufferingThread()
     PRINT_FUNC;
     if ( m_MessageBufferThread )
     {
+        m_MessageBufferThread->join();
         m_MessageBufferThread = nullptr;
     }
 }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -220,7 +220,7 @@ void OrbitApp::ProcessBufferedCaptureData()
         {
             ScopeLock lock( m_SamplingCallstackMutex );
             if (m_SamplingCallstackBuffer.size() > 0){
-                std::string messageData = SerializeObjectHumanReadable(m_SamplingCallstackBuffer);
+                std::string messageData = SerializeObjectBinary(m_SamplingCallstackBuffer);
                 GTcpServer->Send(Msg_SamplingCallstacks, messageData.c_str(), messageData.size());
                 m_SamplingCallstackBuffer.clear();
             }
@@ -230,7 +230,7 @@ void OrbitApp::ProcessBufferedCaptureData()
         {
             ScopeLock lock( m_HashedSamplingCallstackMutex );
             if (m_HashedSamplingCallstackBuffer.size() > 0){  
-                std::string messageData = SerializeObjectHumanReadable(m_HashedSamplingCallstackBuffer);
+                std::string messageData = SerializeObjectBinary(m_HashedSamplingCallstackBuffer);
                 GTcpServer->Send(Msg_SamplingHashedCallstacks, messageData.c_str(), messageData.size());
                 m_HashedSamplingCallstackBuffer.clear();
             }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -230,8 +230,9 @@ void OrbitApp::ProcessBufferedCaptureData()
 
         // context switches
         if (m_ContextSwitchBuffer.size() > 0){
-            std::string message_data = SerializeObjectHumanReadable(m_ContextSwitchBuffer);
-            GTcpServer->Send(Msg_RemoteContextSwitches, (void*) message_data.c_str(), message_data.size());
+            Message Msg(Msg_RemoteContextSwitches);
+            Msg.m_Size = sizeof(ContextSwitch) * m_ContextSwitchBuffer.size();
+            GTcpServer->Send(Msg, (void*)m_ContextSwitchBuffer.data());
             m_ContextSwitchBuffer.clear();
         }
     }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -176,15 +176,70 @@ void GLoadPdbAsync( const std::vector<std::wstring> & a_Modules )
     GModuleManager.LoadPdbAsync( a_Modules, [](){ GOrbitApp->OnPdbLoaded(); } );
 }
 
+//TODO: find a better name
+//-----------------------------------------------------------------------------
+void OrbitApp::StartRemoteCaptureBufferingThread()
+{
+    PRINT_FUNC;
+    m_MessageBufferThread = std::make_shared<std::thread>(&OrbitApp::ProcessBufferedCaptureData, this);
+    m_MessageBufferThread->detach();
+}
+
+//-----------------------------------------------------------------------------
+void OrbitApp::StopRemoteCaptureBufferingThread()
+{
+    PRINT_FUNC;
+    if ( m_MessageBufferThread )
+    {
+        m_MessageBufferThread = nullptr;
+    }
+}
+
+//-----------------------------------------------------------------------------
+void OrbitApp::ProcessBufferedCaptureData()
+{
+    while (Capture::IsCapturing())
+    {  
+        usleep(20000);
+        ScopeLock lock( m_MessageBufferMutex );
+        // timers:
+        if (m_TimerBuffer.size() > 0) {
+            Message Msg(Msg_RemoteTimers);
+            Msg.m_Size = sizeof(Timer) * m_TimerBuffer.size();
+            GTcpServer->Send(Msg, (void*)m_TimerBuffer.data());
+            m_TimerBuffer.clear();
+        }
+        
+        // sampling callstacks
+        if (m_SamplingCallstackBuffer.size() > 0){
+            std::string messageData = SerializeObjectHumanReadable(m_SamplingCallstackBuffer);
+            GTcpServer->Send(Msg_SamplingCallstacks, messageData.c_str(), messageData.size());
+            m_SamplingCallstackBuffer.clear();
+        }
+
+        // hashed sampling callstacks
+        if (m_HashedSamplingCallstackBuffer.size() > 0){  
+            std::string messageData = SerializeObjectHumanReadable(m_HashedSamplingCallstackBuffer);
+            GTcpServer->Send(Msg_SamplingHashedCallstacks, messageData.c_str(), messageData.size());
+            m_HashedSamplingCallstackBuffer.clear();
+        }
+
+        // context switches
+        if (m_ContextSwitchBuffer.size() > 0){
+            std::string message_data = SerializeObjectHumanReadable(m_ContextSwitchBuffer);
+            GTcpServer->Send(Msg_RemoteContextSwitches, (void*) message_data.c_str(), message_data.size());
+            m_ContextSwitchBuffer.clear();
+        }
+    }
+}
+
 //-----------------------------------------------------------------------------
 void OrbitApp::ProcessTimer( Timer* a_Timer, const std::string& a_FunctionName )
 {
     if (ConnectionManager::Get().IsService())
     {
-        // TODO: buffer incoming timers before sending them
-        Message Msg(Msg_RemoteTimers);
-        Msg.m_Size = sizeof(Timer);
-        GTcpServer->Send(Msg, (void*)a_Timer);
+        ScopeLock lock( m_MessageBufferMutex );
+        m_TimerBuffer.push_back(*a_Timer);
     }
     else
     {
@@ -193,20 +248,44 @@ void OrbitApp::ProcessTimer( Timer* a_Timer, const std::string& a_FunctionName )
     }
 }
 
-// TODO: This method should try to send the callstack hashes only.
 //-----------------------------------------------------------------------------
 void OrbitApp::ProcessSamplingCallStack(LinuxPerfData& a_CallStack)
 {
     if (ConnectionManager::Get().IsService())
     {
-        std::string messageData = SerializeObjectHumanReadable(a_CallStack);
-        GTcpServer->Send(Msg_SamplingCallstack, messageData.c_str(), messageData.size());
+        // only send the callstack hash, if we know the callstack
+        if (Capture::GSamplingProfiler->HasCallStack(a_CallStack.m_CS.Hash()))
+        {
+            HashedCallStack hashed_call_stack;
+            hashed_call_stack.m_Depth = a_CallStack.m_CS.m_Depth;
+            hashed_call_stack.m_Hash = a_CallStack.m_CS.m_Hash;
+            hashed_call_stack.m_ThreadId = a_CallStack.m_CS.m_ThreadId;
+            HashedLinuxPerfData data;
+            data.m_CS = hashed_call_stack;
+            data.m_time = a_CallStack.m_time;
+
+            ProcessHashedSamplingCallStack( data );
+        }
+        else {
+            ScopeLock lock( m_MessageBufferMutex );
+            m_SamplingCallstackBuffer.push_back(a_CallStack);
+        }
     }
-    else
+
+    Capture::GSamplingProfiler->AddCallStack( a_CallStack.m_CS );
+    GEventTracer.GetEventBuffer().AddCallstackEvent( a_CallStack.m_time, a_CallStack.m_CS.m_Hash, a_CallStack.m_tid );
+}
+
+//-----------------------------------------------------------------------------
+void OrbitApp::ProcessHashedSamplingCallStack(HashedLinuxPerfData& a_CallStack)
+{
+    if (ConnectionManager::Get().IsService())
     {
-        Capture::GSamplingProfiler->AddCallStack( a_CallStack.m_CS );
-        GEventTracer.GetEventBuffer().AddCallstackEvent( a_CallStack.m_time, a_CallStack.m_CS.Hash(), a_CallStack.m_tid );
+        ScopeLock lock( m_MessageBufferMutex );
+        m_HashedSamplingCallstackBuffer.push_back(a_CallStack);
     }
+    Capture::GSamplingProfiler->AddHashedCallStack(a_CallStack.m_CS);
+    GEventTracer.GetEventBuffer().AddCallstackEvent( a_CallStack.m_time, a_CallStack.m_CS.m_Hash, a_CallStack.m_CS.m_ThreadId );
 }
 
 //-----------------------------------------------------------------------------
@@ -222,6 +301,18 @@ void OrbitApp::ProcessCallStack( CallStack& a_CallStack )
     }
 
     Capture::AddCallstack( a_CallStack );
+}
+
+//-----------------------------------------------------------------------------
+void OrbitApp::ProcessContextSwitch( const ContextSwitch& a_CallStack )
+{
+    if (ConnectionManager::Get().IsService())
+    {
+        ScopeLock lock( m_MessageBufferMutex );
+        m_ContextSwitchBuffer.push_back(a_CallStack);
+    }
+
+    GTimerManager->Add( a_CallStack );
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -5,6 +5,7 @@
 
 
 #include "DataViewTypes.h"
+#include "Threading.h"
 
 #include <functional>
 #include <memory>
@@ -17,6 +18,7 @@
 #include "../OrbitCore/Message.h"
 
 struct CallStack;
+struct ContextSwitch;
 class Process;
 
 //-----------------------------------------------------------------------------
@@ -49,6 +51,8 @@ public:
     void Inject(const std::wstring a_FileName);
     virtual void StartCapture();
     virtual void StopCapture();
+    virtual void StartRemoteCaptureBufferingThread();
+    virtual void StopRemoteCaptureBufferingThread();
     void ToggleCapture();
     void OnDisconnect();
     void OnPdbLoaded();
@@ -70,8 +74,11 @@ public:
     virtual void Disassemble( const std::string & a_FunctionName, DWORD64 a_VirtualAddress, const char * a_MachineCode, size_t a_Size );
     virtual void ProcessTimer( Timer* a_Timer, const std::string& a_FunctionName );
     virtual void ProcessSamplingCallStack(LinuxPerfData& a_CallStack);
+    virtual void ProcessHashedSamplingCallStack(HashedLinuxPerfData& a_CallStack);
     virtual void ProcessCallStack( CallStack& a_CallStack );
+    virtual void ProcessContextSwitch( const ContextSwitch& a_CallStack );
     virtual void AddSymbol(uint64_t a_Address, const std::string& a_Module, const std::string& a_Name);
+    void ProcessBufferedCaptureData();
 
     int* GetScreenRes() { return m_ScreenRes; }
 
@@ -165,6 +172,10 @@ private:
     std::vector< WatchCallback >          m_UpdateWatchCallbacks;
     std::vector< SamplingReportCallback > m_SamplingReportsCallbacks;
     std::vector< SamplingReportCallback > m_SelectionReportCallbacks;
+    std::vector< ContextSwitch >          m_ContextSwitchBuffer;
+    std::vector< Timer >                  m_TimerBuffer;
+    std::vector< LinuxPerfData >          m_SamplingCallstackBuffer;
+    std::vector< HashedLinuxPerfData >    m_HashedSamplingCallstackBuffer;
     std::vector< class DataView* >        m_Panels;
     FindFileCallback                      m_FindFileCallback;
 	SaveFileCallback					  m_SaveFileCallback;
@@ -190,6 +201,10 @@ private:
     std::vector< std::shared_ptr< class SamplingReport> > m_SamplingReports;
     std::map< std::wstring, std::wstring > m_FileMapping;
     std::function< void( const std::wstring & ) > m_UiCallback;
+
+    // buffering data to send large messages instead of small ones:
+    std::shared_ptr<std::thread> m_MessageBufferThread = nullptr;
+    Mutex m_MessageBufferMutex;
 
     std::wstring m_User;
     std::wstring m_License;

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -73,8 +73,8 @@ public:
     void RefreshWatch();
     virtual void Disassemble( const std::string & a_FunctionName, DWORD64 a_VirtualAddress, const char * a_MachineCode, size_t a_Size );
     virtual void ProcessTimer( Timer* a_Timer, const std::string& a_FunctionName );
-    virtual void ProcessSamplingCallStack(LinuxPerfData& a_CallStack);
-    virtual void ProcessHashedSamplingCallStack(HashedLinuxPerfData& a_CallStack);
+    virtual void ProcessSamplingCallStack(LinuxCallstackEvent& a_CallStack);
+    virtual void ProcessHashedSamplingCallStack(CallstackEvent& a_CallStack);
     virtual void ProcessCallStack( CallStack& a_CallStack );
     virtual void ProcessContextSwitch( const ContextSwitch& a_CallStack );
     virtual void AddSymbol(uint64_t a_Address, const std::string& a_Module, const std::string& a_Name);
@@ -172,10 +172,6 @@ private:
     std::vector< WatchCallback >          m_UpdateWatchCallbacks;
     std::vector< SamplingReportCallback > m_SamplingReportsCallbacks;
     std::vector< SamplingReportCallback > m_SelectionReportCallbacks;
-    std::vector< ContextSwitch >          m_ContextSwitchBuffer;
-    std::vector< Timer >                  m_TimerBuffer;
-    std::vector< LinuxPerfData >          m_SamplingCallstackBuffer;
-    std::vector< HashedLinuxPerfData >    m_HashedSamplingCallstackBuffer;
     std::vector< class DataView* >        m_Panels;
     FindFileCallback                      m_FindFileCallback;
 	SaveFileCallback					  m_SaveFileCallback;
@@ -204,7 +200,14 @@ private:
 
     // buffering data to send large messages instead of small ones:
     std::shared_ptr<std::thread> m_MessageBufferThread = nullptr;
-    Mutex m_MessageBufferMutex;
+    std::vector< ContextSwitch >        m_ContextSwitchBuffer;
+    Mutex                               m_ContextSwitchMutex;
+    std::vector< Timer >                m_TimerBuffer;
+    Mutex                               m_TimerMutex;
+    std::vector< LinuxCallstackEvent >        m_SamplingCallstackBuffer;
+    Mutex                               m_SamplingCallstackMutex;
+    std::vector< CallstackEvent >       m_HashedSamplingCallstackBuffer;
+    Mutex                               m_HashedSamplingCallstackMutex;
 
     std::wstring m_User;
     std::wstring m_License;


### PR DESCRIPTION
This will enable remote context-switch information tracking. As there are several thousands context-switches per second, this will buffer the context-switches and send them as a single message via a separate thread each 0.02 seconds. 
The same thread will also do this buffering for callstacks and timers. 
Furthermore, callstacks that are already known, will be only send using there hash and the timestamp.
