### PR TITLE
Compile time checks for consistent memory layout.

### DIFF
--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -6,6 +6,7 @@
 #include "Serialization.h"
 
 //-----------------------------------------------------------------------------
+#pragma pack(push, 1)
 struct ContextSwitch
 {
 public:
@@ -21,3 +22,10 @@ public:
 
     ORBIT_SERIALIZABLE;
 };
+#pragma pack(pop)
+static_assert(sizeof(ContextSwitch) == 19);
+static_assert(offsetof(ContextSwitch, m_ThreadId) == 0);
+static_assert(offsetof(ContextSwitch, m_Type) == 4);
+static_assert(offsetof(ContextSwitch, m_Time) == 8);
+static_assert(offsetof(ContextSwitch, m_ProcessorIndex) == 16);
+static_assert(offsetof(ContextSwitch, m_ProcessorNumber) == 18);

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -10,6 +10,7 @@
 extern thread_local int CurrentDepth;
 
 //-----------------------------------------------------------------------------
+#pragma pack(push, 1)
 class Timer
 {
 public:
@@ -72,6 +73,18 @@ public:
     TickType m_Start;
     TickType m_End;
 };
+#pragma pack(pop)
+static_assert(sizeof(Timer) == 56);
+static_assert(offsetof(Timer, m_TID) == 0);
+static_assert(offsetof(Timer, m_Depth) == 4);
+static_assert(offsetof(Timer, m_SessionID) == 5);
+static_assert(offsetof(Timer, m_Type) == 6);
+static_assert(offsetof(Timer, m_Processor) == 7);
+static_assert(offsetof(Timer, m_CallstackHash) == 8);
+static_assert(offsetof(Timer, m_FunctionAddress) == 16);
+static_assert(offsetof(Timer, m_UserData) == 24);
+static_assert(offsetof(Timer, m_Start) == 40);
+static_assert(offsetof(Timer, m_End) == 48);
 
 //-----------------------------------------------------------------------------
 class ScopeTimer


### PR DESCRIPTION
Added pragma packed and static assertions in order to ensure that sending raw timers and raw context-switches is more safe, i.e. the memory layout is the same on different machines.
