### PR TITLE
Improved dynamic instrumentation using perf_event_open, by increasing…

### DIFF
--- a/OrbitCore/BpfTrace.cpp
+++ b/OrbitCore/BpfTrace.cpp
@@ -350,7 +350,7 @@ void BpfTrace::RunPerfEventOpen(bool* a_ExitRequested)
     {
         while (!(*a_ExitRequested))
         {
-            usleep(10000);
+            OrbitSleepMs(10);
             event_buffer->ProcessTillOffset();
         }
         event_buffer->ProcessAll();
@@ -367,11 +367,11 @@ void BpfTrace::RunPerfEventOpen(bool* a_ExitRequested)
     while( !(*a_ExitRequested) )
     {
         // Lets sleep a bit, such that we are not constantly reading from the buffers
-        // and thus wasting cpu time. 10000 microseconds are still small enough to 
+        // and thus wasting cpu time. 10 milliseconds are still small enough to 
         // not have our buffers overflown and therefore losing events.
         if (!new_events)
         {
-            usleep(10000);
+            OrbitSleepMs(10);
         }
 
         new_events = false;

--- a/OrbitCore/BpfTrace.h
+++ b/OrbitCore/BpfTrace.h
@@ -7,7 +7,6 @@
 #include "ScopeTimer.h"
 #include "OrbitFunction.h"
 #include "Callstack.h"
-#include "LinuxPerfEventProcessor.h"
 #include <vector>
 #include <string>
 #include <map>

--- a/OrbitCore/BpfTrace.h
+++ b/OrbitCore/BpfTrace.h
@@ -7,6 +7,7 @@
 #include "ScopeTimer.h"
 #include "OrbitFunction.h"
 #include "Callstack.h"
+#include "LinuxPerfEventProcessor.h"
 #include <vector>
 #include <string>
 #include <map>

--- a/OrbitCore/LinuxPerfEventProcessor.h
+++ b/OrbitCore/LinuxPerfEventProcessor.h
@@ -53,10 +53,10 @@ class LinuxPerfEventProcessor
 {
 public:
     // While processing, we do not touch the events with a timestamp less 
-    // than 3/10 sec smaller than the most recent one in the queue.
+    // than 300 msecs smaller than the most recent one in the queue.
     // This way we can ensure, that all events (from different sources)
     // are processed in the correct order.
-    const uint64_t DELAY_IN_NS = 300000000 /*ns*/;
+    const uint64_t DELAY_IN_MS = 300 /*ms*/;
 
     LinuxPerfEventProcessor(std::unique_ptr<LinuxPerfEventVisitor> a_Visitor) :
         m_Visitor(std::move(a_Visitor))
@@ -81,6 +81,8 @@ private:
     uint64_t m_MaxTimestamp = 0;
 
     Mutex m_Mutex;
+
+    std::unique_ptr<LinuxPerfEvent> TryDequeue();
 
     #ifndef NDEBUG
     uint64_t m_LastProcessTimestamp = 0;


### PR DESCRIPTION
… the offset and do the processing in a different thread. Therefore, LinuxPerfEventProcessor is now also thread-safe.