### PR TITLE
Fix clock usage in perf_event_open call, which aligns the sched event timeline with the other timelines

### DIFF
--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -73,10 +73,8 @@ void ConnectionManager::ConnectToRemote(std::string a_RemoteAddress)
 //-----------------------------------------------------------------------------
 void ConnectionManager::InitAsService()
 {
-    // TODO: In their current state, context switches on linux are not in the
-    // same time domain as the sampling events.  Disable until the issue is fixed.
     #if __linux__
-    GParams.m_TrackContextSwitches = false;
+    GParams.m_TrackContextSwitches = true;
     #endif
 
     m_IsService = true;

--- a/OrbitCore/LinuxPerfUtils.cpp
+++ b/OrbitCore/LinuxPerfUtils.cpp
@@ -21,6 +21,7 @@ perf_event_attr LinuxPerfUtils::generic_perf_event_attr()
     perf_event_attr pe{};
     pe.size = sizeof(struct perf_event_attr);
     pe.sample_period = 1;
+    pe.use_clockid = 1;
     pe.clockid = CLOCK_MONOTONIC;
     pe.sample_id_all = 1; // also include timestamps for lost events
     pe.disabled = 1;


### PR DESCRIPTION
Calls to perf_event_open were not setting use_clockid in the options (which is "0" by default) and hence the clock parameter to use the monotonic clock was not used. This caused events from perf_event_open and other events from "perf record" and bpftrace to be on different clocks. We still need to verify that the results are really correct now but from visual inspection of the timeline it looks like they are (dynamically instrumented function calls have corresponding thread slices in the sched timeline). 

This PR also reenables Linux sched events (context switches). 