### PR TITLE
Print string error message returned by perf_event_open instead of the error number

### DIFF
--- a/OrbitCore/LinuxPerfUtils.cpp
+++ b/OrbitCore/LinuxPerfUtils.cpp
@@ -47,7 +47,7 @@ int32_t LinuxPerfUtils::task_event_open(int32_t a_CPU) {
 
     if (fd == -1)
     {
-        PRINT("perf_event_open error: %d\n", errno);
+        PRINT("perf_event_open error: %s\n", strerror(errno));
     }
 
     return fd;
@@ -65,7 +65,7 @@ int32_t LinuxPerfUtils::context_switch_open(pid_t a_PID, int32_t a_CPU)
 
     if (fd == -1)
     {
-        PRINT("perf_event_open error: %d\n", errno);
+        PRINT("perf_event_open error: %s\n", strerror(errno));
     }
 
     return fd;
@@ -89,7 +89,7 @@ int32_t LinuxPerfUtils::tracepoint_event_open(
 
     if (fd == -1)
     {
-        PRINT("perf_event_open error: %d\n", errno);
+        PRINT("perf_event_open error: %s\n", strerror(errno));
     }
 
     return fd;
@@ -131,7 +131,7 @@ int32_t LinuxPerfUtils::uprobe_event_open(
 
     if (fd == -1)
     {
-        PRINT("perf_event_open error: %d\n", errno);
+        PRINT("perf_event_open error: %s\n", strerror(errno));
     }
 
     PRINT_VAR(fd);
@@ -168,7 +168,7 @@ int32_t LinuxPerfUtils::uretprobe_event_open(
 
     if (fd == -1)
     {
-        PRINT("perf_event_open error: %d\n", errno);
+        PRINT("perf_event_open error: %s\n", strerror(errno));
     }
 
     PRINT_VAR(fd);


### PR DESCRIPTION
When perf_event_open fails, it returns an error number (just as every Linux syscall). So far, we have only printed the error number (example: "13" in the permission denied case). We now use strerror to get the actual string error message for easier readability of the printed error.