### PR TITLE
Fixed crash on app exit.

### DIFF
--- a/OrbitCore/TcpEntity.cpp
+++ b/OrbitCore/TcpEntity.cpp
@@ -40,8 +40,10 @@ void TcpEntity::Stop()
         m_ExitRequested = true;
     }
 
-    m_ConditionVariable.signal();
-    m_SenderThread->join();
+    if (m_SenderThread) {
+        m_ConditionVariable.signal();
+        m_SenderThread->join();
+    }
     
     if( m_TcpSocket && m_TcpSocket->m_Socket )
     {

--- a/OrbitCore/TcpEntity.h
+++ b/OrbitCore/TcpEntity.h
@@ -80,7 +80,7 @@ protected:
 protected:
     TcpService*                m_TcpService;
     TcpSocket*                 m_TcpSocket;
-    std::thread*               m_SenderThread;
+    std::thread*               m_SenderThread = nullptr;
     AutoResetEvent             m_ConditionVariable;
     LockFreeQueue< TcpPacket > m_SendQueue;
     std::atomic<int>           m_NumQueuedEntries;


### PR DESCRIPTION
m_SenderThread is only initialized on first use.
In case it's never used, we can't join it while
exiting.

On Linux you probably won't notice, but I expect
on Windows the "Program crashed" dialog to pop up.