### PR TITLE
Added better process name sanitization.

### DIFF
--- a/OrbitCore/ProcessUtils.cpp
+++ b/OrbitCore/ProcessUtils.cpp
@@ -50,33 +50,34 @@ int IsNumeric(const char* ccharptr_CharacterList)
 
 #ifndef _WIN32
 namespace  {
-std::string PrettifyProcessName(const std::string &processName) {
-  // Idea: processName contains (if not changed by the process) a
-  // null-separated list of arguments, while the first is the path to the
-  // executable as called by the user. We check wether that first string is a
-  // file path. If so, we search for the last forward slash in this string and
-  // copy from there up to the end of the whole string. So we get the
-  // executable name and the arguments.
+std::string PrettifyProcessName(const std::string &processName)
+{
+    // Idea: processName contains (if not changed by the process) a
+    // null-separated list of arguments, while the first is the path to the
+    // executable as called by the user. We check wether that first string is a
+    // file path. If so, we search for the last forward slash in this string and
+    // copy from there up to the end of the whole string. So we get the
+    // executable name and the arguments.
 
-  auto resultingName = [&]() -> std::string {
-    const auto end = std::find(processName.begin(), processName.end(), '\0');
+    auto resultingName = [&]() -> std::string {
+        const auto end = std::find(processName.begin(), processName.end(), '\0');
 
-    const std::string filepath{processName.begin(), end};
+        const std::string filepath{processName.begin(), end};
 
-    struct stat st{};
-    const auto result = stat(filepath.c_str(), &st);
+        struct stat st{};
+        const auto result = stat(filepath.c_str(), &st);
 
-    if (result == 0) {
-        // We found a file
-        const auto begin = std::find(std::make_reverse_iterator(end),
-                                     processName.rend(), '/');
-        return std::string{begin.base(), processName.end()};
-    }
-    return processName;
-  }();
+        if (result == 0) {
+            // We found a file
+            const auto begin = std::find(std::make_reverse_iterator(end),
+                                         processName.rend(), '/');
+            return std::string{begin.base(), processName.end()};
+        }
+        return processName;
+    }();
 
-  std::replace(resultingName.begin(), resultingName.end(), '\0', ' ');
-  return resultingName;
+    std::replace(resultingName.begin(), resultingName.end(), '\0', ' ');
+    return resultingName;
 }
 } // namespace
 #endif


### PR DESCRIPTION
The current process name shortening implementation assumes the process name to always be a file path, which might not be the case under Linux.

This small helper method applies file path shortening only if an actual file is found. If not, it assumes
the process changed its name to a custom string and does not apply shortening. Further arguments are preserved anyway.

Examples:
"/bin/bash" shortens to "bash"
"/usr/sbin/cupsd -l" shortens to "cupsd -l"
"/opt/google/chrome/chrome --type=renderer..." is not shortened since the process name is managed by chrome.