### PR TITLE
Added few additional entries to the .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ external/minhook/bin/
 build/
 /.idea/
 /cmake-build*/
+.clangd/
+compile_commands.json


### PR DESCRIPTION
I use clangd in my dev setup. clangd created an index folder
under .clangd/. Furthermore clangd reads its configuration
from a compile_commands.json file, which is usually a symbolic
link to the one created by cmake in the build-directory.