### PR TITLE
Dynamic instrumentation with perf_event_open

### DIFF
--- a/OrbitCore/BpfTrace.cpp
+++ b/OrbitCore/BpfTrace.cpp
@@ -37,22 +37,6 @@ using namespace LinuxPerfUtils;
 //-----------------------------------------------------------------------------
 BpfTrace::BpfTrace(Callback a_Callback) {
 #if __linux__
-
-  // Until perf_events are fixed...
-  GParams.m_UseBpftrace = true;
-
-  // TODO: we shouldn't hijack the BpfTrace class and move perf_event related
-  //       code to its own class.
-
-  // Uprobe perf_events not supported until Kernel 4.17
-  if (LinuxPerfUtils::supports_perf_event_uprobes()) {
-    m_UsePerfEvents = !GParams.m_UseBpftrace && !GParams.m_BpftraceCallstacks;
-  } else {
-    m_UsePerfEvents = false;
-  }
-
-  PRINT_VAR(m_UsePerfEvents);
-
   m_Callback = a_Callback ? a_Callback : [this](const std::string& a_Buffer) {
     if (GParams.m_BpftraceCallstacks)
       CommandCallbackWithCallstacks(a_Buffer);
@@ -74,14 +58,9 @@ void BpfTrace::Start() {
 
   m_BpfCommand = std::string("bpftrace ") + m_ScriptFileName;
 
-  if (!m_UsePerfEvents) {
-    m_Thread = std::make_shared<std::thread>(&LinuxUtils::StreamCommandOutput,
-                                             m_BpfCommand.c_str(), m_Callback,
-                                             &m_ExitRequested);
-  } else {
-    m_Thread = std::make_shared<std::thread>(BpfTrace::RunPerfEventOpen,
-                                             &m_ExitRequested);
-  }
+  m_Thread = std::make_shared<std::thread>(&LinuxUtils::StreamCommandOutput,
+                                           m_BpfCommand.c_str(), m_Callback,
+                                           &m_ExitRequested);
 
   m_Thread->detach();
 #endif
@@ -100,7 +79,7 @@ std::string BpfTrace::GetBpfScript() {
 
   for (Function* func : Capture::GTargetProcess->GetFunctions()) {
     if (func->IsSelected()) {
-      uint64_t virtual_address = (uint64_t)func->GetVirtualAddress();
+      auto virtual_address = static_cast<uint64_t>(func->GetVirtualAddress());
       Capture::GSelectedFunctionsMap[func->m_Address] = func;
 
       if (GParams.m_BpftraceCallstacks) {
@@ -170,7 +149,7 @@ void BpfTrace::CommandCallback(const std::string& a_Line) {
 
   if (isEnd) {
     std::vector<Timer>& timers = m_TimerStacks[threadName];
-    if (timers.size()) {
+    if (!timers.empty()) {
       Timer& timer = timers.back();
       uint64_t nanos = std::stoull(timestamp);
       timer.m_End = nanos;
@@ -237,11 +216,11 @@ void BpfTrace::CommandCallbackWithCallstacks(const std::string& a_Line) {
   }
 
   if (isEndOfStack) {
-    if (m_CallStack.m_Data.size()) {
+    if (!m_CallStack.m_Data.empty()) {
       m_CallStack.m_Depth = (uint32_t)m_CallStack.m_Data.size();
       m_CallStack.m_ThreadId = atoi(m_LastThreadName.c_str());
       std::vector<Timer>& timers = m_TimerStacks[m_LastThreadName];
-      if (timers.size()) {
+      if (!timers.empty()) {
         Timer& timer = timers.back();
         timer.m_CallstackHash = m_CallStack.Hash();
         GCoreApp->ProcessCallStack(m_CallStack);
@@ -281,325 +260,4 @@ void BpfTrace::CommandCallbackWithCallstacks(const std::string& a_Line) {
     }
     return;
   }
-}
-
-//-----------------------------------------------------------------------------
-void BpfTrace::RunPerfEventOpen(bool* a_ExitRequested) {
-#if __linux__
-  SCOPE_TIMER_FUNC;
-  int ROUND_ROBIN_BATCH_SIZE = 5;
-  std::vector<uint64_t> fds;
-  std::map<Function*, LinuxPerfRingBuffer> uprobe_ring_buffers;
-  std::map<Function*, LinuxPerfRingBuffer> uretprobe_ring_buffers;
-
-  for (const auto& pair : Capture::GSelectedFunctionsMap) {
-    // gather function information
-    Function* function = pair.second;
-    uint64_t offset = function->m_Address;
-    std::string module = ws2s(function->m_Pdb->GetFileName());
-
-    // create uprobe for that function on that PID profiling all cpus
-    uint64_t uprobe_fd = 0;
-    if (GParams.m_BpftraceCallstacks)
-      uprobe_fd = LinuxPerfUtils::uprobe_event_open(
-          module.c_str(), offset, Capture::GTargetProcess->GetID(), -1,
-          PERF_SAMPLE_STACK_USER | PERF_SAMPLE_REGS_USER);
-    else
-      uprobe_fd = LinuxPerfUtils::uprobe_event_open(
-          module.c_str(), offset, Capture::GTargetProcess->GetID(), -1);
-
-    uprobe_ring_buffers.emplace(function, uprobe_fd);
-    fds.push_back(uprobe_fd);
-
-    // create uretprobe for that function on that PID profiling all cpus
-    uint64_t uretprobe_fd = LinuxPerfUtils::uretprobe_event_open(
-        module.c_str(), offset, Capture::GTargetProcess->GetID(), -1);
-    uretprobe_ring_buffers.emplace(function, uretprobe_fd);
-    fds.push_back(uretprobe_fd);
-
-    // start capturing
-    LinuxPerfUtils::start_capturing(uprobe_fd);
-    LinuxPerfUtils::start_capturing(uretprobe_fd);
-  }
-
-  LinuxPerfEventProcessor event_buffer(std::make_unique<BpfTraceVisitor>());
-
-  bool new_events = false;
-
-  while (!(*a_ExitRequested)) {
-    // Lets sleep a bit, such that we are not constantly reading from the
-    // buffers and thus wasting cpu time. 10000 microseconds are still small
-    // enough to not have our buffers overflown and therefore losing events.
-    if (!new_events) {
-      usleep(10000);
-    }
-
-    new_events = false;
-
-    // read from all ring buffers, create events and store them in the
-    // event_queue
-    // TODO: implement a better scheduling strategy.
-    for (auto& pair : uprobe_ring_buffers) {
-      auto& ring_buffer = pair.second;
-      int i = 0;
-      // read everything that is new
-      while (ring_buffer.HasNewData() && i < ROUND_ROBIN_BATCH_SIZE) {
-        i++;
-        new_events = true;
-        perf_event_header header{};
-        ring_buffer.ReadHeader(&header);
-
-        // perf_event_header::type contains the type of record,
-        // defined in enum perf_event_type in perf_event.h.
-        switch (header.type) {
-          case PERF_RECORD_SAMPLE: {
-            SCOPE_TIMER_LOG("PERF_RECORD_SAMPLE");
-            if (GParams.m_BpftraceCallstacks) {
-              auto record =
-                  ring_buffer.ConsumeRecord<LinuxUprobeEventWithStack>(header);
-              record.SetFunction(pair.first);
-              event_buffer.Push(std::make_unique<LinuxUprobeEventWithStack>(
-                  std::move(record)));
-            } else {
-              auto record = ring_buffer.ConsumeRecord<LinuxUprobeEvent>(header);
-              record.SetFunction(pair.first);
-              event_buffer.Push(
-                  std::make_unique<LinuxUprobeEvent>(std::move(record)));
-            }
-
-          } break;
-          case PERF_RECORD_LOST: {
-            auto lost = ring_buffer.ConsumeRecord<LinuxPerfLostEvent>(header);
-            PRINT("Lost %u Events\n", lost.Lost());
-          } break;
-          default:
-            PRINT("Unexpected Perf Sample Type: %u", header.type);
-            ring_buffer.SkipRecord(header);
-            break;
-        }
-      }
-    }
-
-    for (auto& pair : uretprobe_ring_buffers) {
-      auto& ring_buffer = pair.second;
-      int i = 0;
-      // read everything that is new
-      while (ring_buffer.HasNewData() && i < ROUND_ROBIN_BATCH_SIZE) {
-        i++;
-        new_events = true;
-        perf_event_header header{};
-        ring_buffer.ReadHeader(&header);
-
-        // perf_event_header::type contains the type of record,
-        // defined in enum perf_event_type in perf_event.h.
-        switch (header.type) {
-          case PERF_RECORD_SAMPLE: {
-            PRINT("Consuming uretprobe record...");
-            auto record =
-                ring_buffer.ConsumeRecord<LinuxUretprobeEvent>(header);
-            record.SetFunction(pair.first);
-            event_buffer.Push(
-                std::make_unique<LinuxUretprobeEvent>(std::move(record)));
-          } break;
-          case PERF_RECORD_LOST: {
-            auto lost = ring_buffer.ConsumeRecord<LinuxPerfLostEvent>(header);
-            PRINT("Lost %u Events\n", lost.Lost());
-          } break;
-          default:
-            PRINT("Unexpected Perf Sample Type: %u", header.type);
-            ring_buffer.SkipRecord(header);
-            break;
-        }
-      }
-    }
-
-    event_buffer.ProcessTillOffset();
-  }
-
-  for (auto fd : fds) {
-    LinuxPerfUtils::stop_capturing(fd);
-  }
-
-  event_buffer.ProcessAll();
-#endif
-}
-
-//-----------------------------------------------------------------------------
-void BpfTrace::RunPerfEventOpenSingleBuffers(bool* a_ExitRequested) {
-#if __linux__
-  SCOPE_TIMER_FUNC;
-
-  int ROUND_ROBIN_BATCH_SIZE = 5;
-  std::vector<uint64_t> fds;
-  std::shared_ptr<LinuxPerfRingBuffer> uprobe_ring_buffer;
-  std::shared_ptr<LinuxPerfRingBuffer> uretprobe_ring_buffer;
-  uint64_t sampleType = GParams.m_BpftraceCallstacks
-                            ? (PERF_SAMPLE_STACK_USER | PERF_SAMPLE_REGS_USER)
-                            : 0;
-
-  int32_t master_uprobe_fd = -1;
-  int32_t master_uretprobe_fd = -1;
-  Function* dummyFunction = nullptr;
-
-  // Functions to instument.
-  std::set<Function*> selectedFunctions;
-  for (const auto& pair : Capture::GSelectedFunctionsMap) {
-    selectedFunctions.insert(pair.second);
-    dummyFunction = pair.second;
-  }
-
-  for (Function* function : selectedFunctions) {
-    // gather function information
-    uint64_t offset = function->m_Address;
-    std::string module = ws2s(function->m_Pdb->GetFileName());
-    PRINT_VAR(offset);
-    PRINT_VAR(module);
-
-    // create uprobe for that function on that PID profiling all cpus
-    int32_t uprobe_fd = LinuxPerfUtils::uprobe_event_open(
-        module.c_str(), offset, Capture::GTargetProcess->GetID(), -1,
-        master_uprobe_fd, sampleType);
-
-    // create uretprobe for that function on that PID profiling all cpus
-    int32_t uretprobe_fd = LinuxPerfUtils::uretprobe_event_open(
-        module.c_str(), offset, Capture::GTargetProcess->GetID(), -1, -1);
-
-    // Check that both uprobe and uretprobe were created successfully
-    if (uprobe_fd == -1 || uretprobe_fd == -1) {
-      PRINT("Uprobe/Uretprobe error. uprobe_fd:%i uretprobe_fd:%i", uprobe_fd,
-            uretprobe_fd);
-      continue;
-    }
-
-    if (master_uprobe_fd == -1) {
-      master_uprobe_fd = uprobe_fd;
-      master_uretprobe_fd = uretprobe_fd;
-      uprobe_ring_buffer = std::make_shared<LinuxPerfRingBuffer>(uprobe_fd);
-      uretprobe_ring_buffer =
-          std::make_shared<LinuxPerfRingBuffer>(uretprobe_fd);
-    } else {
-      // Redirect events to master event buffer
-      int ret = ioctl(uprobe_fd, PERF_EVENT_IOC_SET_OUTPUT, master_uprobe_fd);
-      if (ret) PRINT("PERF_EVENT_IOC_SET_OUTPUT error: %i.\n", ret);
-      ret = ioctl(uretprobe_fd, PERF_EVENT_IOC_SET_OUTPUT, master_uretprobe_fd);
-      if (ret) PRINT("PERF_EVENT_IOC_SET_OUTPUT error: %i.\n", ret);
-    }
-
-    fds.push_back(uprobe_fd);
-    fds.push_back(uretprobe_fd);
-
-    PRINT_VAR(uprobe_fd);
-    PRINT_VAR(uretprobe_fd);
-  }
-
-  // start capturing
-  for (auto fd : fds) {
-    LinuxPerfUtils::start_capturing(fd);
-  }
-
-  LinuxPerfEventProcessor event_buffer(std::make_unique<BpfTraceVisitor>());
-
-  bool new_events = false;
-
-  while (!(*a_ExitRequested)) {
-    // Lets sleep a bit, such that we are not constantly reading from the
-    // buffers and thus wasting cpu time. 10000 microseconds are still small
-    // enough to not have our buffers overflown and therefore losing events.
-    if (!new_events) {
-      usleep(10000);
-    }
-
-    new_events = false;
-
-    // read from all ring buffers, create events and store them in the
-    // event_queue
-    // TODO: implement a better scheduling strategy.
-
-    // uprobes
-    {
-      auto ring_buffer = uprobe_ring_buffer;
-      int i = 0;
-
-      // read everything that is new
-      while (ring_buffer->HasNewData() && i < ROUND_ROBIN_BATCH_SIZE) {
-        i++;
-        new_events = true;
-        perf_event_header header{};
-        ring_buffer->ReadHeader(&header);
-
-        // perf_event_header::type contains the type of record,
-        // defined in enum perf_event_type in perf_event.h.
-        switch (header.type) {
-          case PERF_RECORD_SAMPLE: {
-            PRINT("Consuming uprobe buffer\n");
-            if (GParams.m_BpftraceCallstacks) {
-              auto record =
-                  ring_buffer->ConsumeRecord<LinuxUprobeEventWithStack>(header);
-              record.SetFunction(dummyFunction);
-              event_buffer.Push(std::make_unique<LinuxUprobeEventWithStack>(
-                  std::move(record)));
-            } else {
-              auto record =
-                  ring_buffer->ConsumeRecord<LinuxUprobeEvent>(header);
-              record.SetFunction(dummyFunction);
-              event_buffer.Push(
-                  std::make_unique<LinuxUprobeEvent>(std::move(record)));
-            }
-
-          } break;
-          case PERF_RECORD_LOST: {
-            auto lost = ring_buffer->ConsumeRecord<LinuxPerfLostEvent>(header);
-            PRINT("Lost %u Events\n", lost.Lost());
-          } break;
-          default:
-            PRINT("Unexpected Perf Sample Type: %u", header.type);
-            ring_buffer->SkipRecord(header);
-            break;
-        }
-      }
-    }
-
-    // uretprobes
-    {
-      auto& ring_buffer = uretprobe_ring_buffer;
-      int i = 0;
-      // read everything that is new
-      while (ring_buffer->HasNewData() && i < ROUND_ROBIN_BATCH_SIZE) {
-        i++;
-        new_events = true;
-        perf_event_header header{};
-        ring_buffer->ReadHeader(&header);
-
-        // perf_event_header::type contains the type of record,
-        // defined in enum perf_event_type in perf_event.h.
-        switch (header.type) {
-          case PERF_RECORD_SAMPLE: {
-            // PRINT("Consuming uretprobe record...");
-            auto record =
-                ring_buffer->ConsumeRecord<LinuxUretprobeEvent>(header);
-            record.SetFunction(dummyFunction);
-            event_buffer.Push(
-                std::make_unique<LinuxUretprobeEvent>(std::move(record)));
-          } break;
-          case PERF_RECORD_LOST: {
-            auto lost = ring_buffer->ConsumeRecord<LinuxPerfLostEvent>(header);
-            PRINT("Lost %u Events\n", lost.Lost());
-          } break;
-          default:
-            PRINT("Unexpected Perf Sample Type: %u", header.type);
-            ring_buffer->SkipRecord(header);
-            break;
-        }
-      }
-    }
-
-    event_buffer.ProcessTillOffset();
-  }
-
-  for (auto fd : fds) {
-    LinuxPerfUtils::stop_capturing(fd);
-  }
-
-  event_buffer.ProcessAll();
-#endif
 }

--- a/OrbitCore/BpfTrace.h
+++ b/OrbitCore/BpfTrace.h
@@ -1,6 +1,7 @@
 //-----------------------------------
 // Copyright Pierric Gimmig 2013-2017
 //-----------------------------------
+
 #pragma once
 
 #include <map>
@@ -16,7 +17,7 @@
 class BpfTrace {
  public:
   typedef std::function<void(const std::string& a_Data)> Callback;
-  BpfTrace(Callback a_Callback = nullptr);
+  explicit BpfTrace(Callback a_Callback = nullptr);
 
   void Start();
   void Stop();
@@ -30,8 +31,6 @@ class BpfTrace {
   void CommandCallback(const std::string& a_Line);
   void CommandCallbackWithCallstacks(const std::string& a_Line);
   bool WriteBpfScript();
-  static void RunPerfEventOpen(bool* a_ExitRequested);
-  static void RunPerfEventOpenSingleBuffers(bool* a_ExitRequested);
 
  private:
   std::map<std::string, std::vector<Timer>> m_TimerStacks;
@@ -40,8 +39,6 @@ class BpfTrace {
 
   std::shared_ptr<std::thread> m_Thread;
   bool m_ExitRequested = true;
-  uint32_t m_PID = 0;
-  bool m_UsePerfEvents;
   Callback m_Callback;
   std::string m_Script;
   std::string m_ScriptFileName;

--- a/OrbitCore/BpfTraceVisitor.cpp
+++ b/OrbitCore/BpfTraceVisitor.cpp
@@ -36,3 +36,14 @@ void BpfTraceVisitor::visit(LinuxUprobeEventWithStack* a_Event) {
   timer.m_FunctionAddress = a_Event->GetFunction()->GetVirtualAddress();
   m_TimerStacks[a_Event->TID()].push_back(timer);
 }
+
+void BpfTraceVisitor::visit(LinuxUretprobeEventWithStack* a_Event) {
+  std::vector<Timer>& timers = m_TimerStacks[a_Event->TID()];
+  if (!timers.empty()) {
+    Timer& timer = timers.back();
+    timer.m_End = a_Event->Timestamp();
+    GCoreApp->ProcessTimer(
+        &timer, std::to_string(a_Event->GetFunction()->GetVirtualAddress()));
+    timers.pop_back();
+  }
+}

--- a/OrbitCore/BpfTraceVisitor.h
+++ b/OrbitCore/BpfTraceVisitor.h
@@ -10,6 +10,7 @@ class BpfTraceVisitor : public LinuxPerfEventVisitor {
   void visit(LinuxUprobeEvent* a_Event) override;
   void visit(LinuxUprobeEventWithStack* a_Event) override;
   void visit(LinuxUretprobeEvent* a_Event) override;
+  void visit(LinuxUretprobeEventWithStack* a_Event) override;
 
  private:
   std::map<uint64_t, std::vector<Timer>> m_TimerStacks;

--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -116,9 +116,11 @@ void ConnectionManager::SetSelectedFunctionsOnRemote(const Message& a_Msg) {
 void ConnectionManager::StartCaptureAsRemote() {
   PRINT_FUNC;
   Capture::StartCapture();
-  // TODO: Either we remove BpfTrace soon, or we should use it from a single
-  //  code location (the other one is in App.cpp)
-  m_BpfTrace->Start();
+  if (GParams.m_UseBpftrace) {
+    // TODO: Either we remove BpfTrace soon, or we should use it from a single
+    //  code location (the other one is in App.cpp)
+    m_BpfTrace->Start();
+  }
   GCoreApp->StartRemoteCaptureBufferingThread();
 }
 

--- a/OrbitCore/EventBuffer.cpp
+++ b/OrbitCore/EventBuffer.cpp
@@ -89,6 +89,14 @@ void EventTracer::Start(uint32_t a_PID) {
 
   if (GParams.m_TrackContextSwitches || !GParams.m_SampleWithPerf) {
     m_EventTracer = std::make_shared<LinuxEventTracer>(a_PID);
+
+    std::vector<Function*> selected_functions;
+    selected_functions.reserve(Capture::GSelectedFunctionsMap.size());
+    for (const auto& function : Capture::GSelectedFunctionsMap) {
+      selected_functions.push_back(function.second);
+    }
+    m_EventTracer->SetInstrumentedFunctions(selected_functions);
+
     m_EventTracer->Start();
   }
 }

--- a/OrbitCore/LinuxEventTracer.h
+++ b/OrbitCore/LinuxEventTracer.h
@@ -5,46 +5,110 @@
 //-----------------------------------
 // Author: Florian Kuebler
 //-----------------------------------
-#pragma once
+
+#ifndef ORBIT_CORE_LINUX_EVENT_TRACER_H_
+#define ORBIT_CORE_LINUX_EVENT_TRACER_H_
 
 #include <atomic>
 #include <functional>
 #include <thread>
+#include <utility>
 
 #include "CallstackTypes.h"
 #include "LibunwindstackUnwinder.h"
+#include "OrbitFunction.h"
+#include "PrintVar.h"
 
-//-----------------------------------------------------------------------------
-class LinuxEventTracer {
+class LinuxEventTracerThread {
  public:
-  static const uint32_t ROUND_ROBIN_BATCH_SIZE = 5;
-  using Callback = std::function<void(const std::string& a_Data)>;
+  LinuxEventTracerThread(pid_t pid, double sampling_frequency,
+                         std::vector<Function*> instrumented_functions)
+      : pid_(pid),
+        sampling_frequency_(sampling_frequency),
+        instrumented_functions_(std::move(instrumented_functions)) {}
 
-  explicit LinuxEventTracer(pid_t a_Pid, uint32_t a_Frequency = 1000)
-      : m_Pid{a_Pid}, m_Frequency{a_Frequency} {}
+  LinuxEventTracerThread(const LinuxEventTracerThread&) = delete;
+  LinuxEventTracerThread& operator=(const LinuxEventTracerThread&) = delete;
+  LinuxEventTracerThread(LinuxEventTracerThread&&) = default;
+  LinuxEventTracerThread& operator=(LinuxEventTracerThread&&) = default;
 
-  void Start();
-  void Stop();
-  bool IsRunning() const { return !(*m_ExitRequested); }
-
- protected:
-  void CommandCallback(std::string a_Line);
+  void Run(const std::shared_ptr<std::atomic<bool>>& a_ExitRequested);
 
  private:
-  pid_t m_Pid;
-  uint32_t m_Frequency;
+  // Number of records to read consecutively from a perf_event_open ring buffer
+  // before switching to another one.
+  static constexpr int32_t ROUND_ROBIN_BATCH_SIZE = 5;
 
-  // m_ExitRequested must outlive this object because it is used by m_Thread.
+  pid_t pid_;
+  double sampling_frequency_;
+  std::vector<Function*> instrumented_functions_;
+
+  uint64_t sampling_period_ns_ = 1'000'000;
+  int32_t num_cpus_ = 0;
+
+  bool ComputeSamplingPeriodNs();
+  void LoadNumCpus();
+  static void HandleCallstack(pid_t tid, uint64_t timestamp,
+                              const std::vector<unwindstack::FrameData>& frames);
+};
+
+class LinuxEventTracer {
+ public:
+  static constexpr double DEFAULT_SAMPLING_FREQUENCY = 1000.0;
+
+  LinuxEventTracer(pid_t pid, double sampling_frequency,
+                   std::vector<Function*> instrumented_functions)
+      : pid_{pid}, sampling_frequency_{sampling_frequency},
+        instrumented_functions_{std::move(instrumented_functions)} {}
+
+  explicit LinuxEventTracer(pid_t pid)
+      : LinuxEventTracer{pid, DEFAULT_SAMPLING_FREQUENCY, {}} {}
+
+  LinuxEventTracer(pid_t pid, double sampling_frequency)
+      : LinuxEventTracer{pid, sampling_frequency, {}} {}
+
+  LinuxEventTracer(pid_t pid, std::vector<Function*> instrumented_functions)
+      : LinuxEventTracer{pid, DEFAULT_SAMPLING_FREQUENCY,
+                         std::move(instrumented_functions)} {}
+
+  LinuxEventTracer(const LinuxEventTracer&) = delete;
+  LinuxEventTracer& operator=(const LinuxEventTracer&) = delete;
+  LinuxEventTracer(LinuxEventTracer&&) = default;
+  LinuxEventTracer& operator=(LinuxEventTracer&&) = default;
+
+  void SetInstrumentedFunctions(std::vector<Function*> instrumented_functions) {
+    instrumented_functions_ = std::move(instrumented_functions);
+  }
+
+  void Start() {
+    PRINT_FUNC;
+    *exit_requested_ = false;
+    thread_ = std::make_shared<std::thread>(
+        &LinuxEventTracer::Run,
+        pid_, sampling_frequency_, instrumented_functions_, exit_requested_);
+    thread_->detach();
+  }
+
+  void Stop() { *exit_requested_ = true; }
+
+ private:
+  pid_t pid_;
+  double sampling_frequency_;
+  std::vector<Function*> instrumented_functions_;
+
+  // exit_requested_ must outlive this object because it is used by thread_.
   // The control block of shared_ptr is thread safe (i.e., reference counting
   // and pointee's lifetime management are atomic and thread safe).
-  std::shared_ptr<std::atomic<bool>> m_ExitRequested =
+  std::shared_ptr<std::atomic<bool>> exit_requested_ =
       std::make_unique<std::atomic<bool>>(true);
-  std::shared_ptr<std::thread> m_Thread;
-  Callback m_Callback;
+  std::shared_ptr<std::thread> thread_;
 
-  static void Run(pid_t a_Pid, int32_t a_Frequency,
-                  const std::shared_ptr<std::atomic<bool>>& a_ExitRequested);
-  static void HandleCallstack(
-      ThreadID tid, uint64_t timestamp,
-      const std::vector<unwindstack::FrameData>& frames);
+  static void Run(pid_t pid, double sampling_frequency,
+                  const std::vector<Function*>& instrumented_functions,
+                  const std::shared_ptr<std::atomic<bool>>& exit_requested) {
+    LinuxEventTracerThread{pid, sampling_frequency, instrumented_functions}
+        .Run(exit_requested);
+  }
 };
+
+#endif  // ORBIT_CORE_LINUX_EVENT_TRACER_H_

--- a/OrbitCore/LinuxPerfEvent.cpp
+++ b/OrbitCore/LinuxPerfEvent.cpp
@@ -14,48 +14,43 @@
 // LinuxPerfEventVisitor needs to be an incomplete type to avoid the circular
 // dependency between LinuxPerfEvent.h and LinuxPerfEventVisitor.h.
 
-//-----------------------------------------------------------------------------
 void LinuxPerfLostEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }
 
-//-----------------------------------------------------------------------------
 void LinuxForkEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }
 
-//-----------------------------------------------------------------------------
 void LinuxExitEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }
 
-//-----------------------------------------------------------------------------
 void LinuxContextSwitchEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }
 
-//-----------------------------------------------------------------------------
 void LinuxSystemWideContextSwitchEvent::accept(
     LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }
 
-//-----------------------------------------------------------------------------
 void LinuxStackSampleEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }
 
-//-----------------------------------------------------------------------------
 void LinuxUprobeEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }
 
-//-----------------------------------------------------------------------------
 void LinuxUprobeEventWithStack::accept(LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }
 
-//-----------------------------------------------------------------------------
 void LinuxUretprobeEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
+  a_Visitor->visit(this);
+}
+
+void LinuxUretprobeEventWithStack::accept(LinuxPerfEventVisitor* a_Visitor) {
   a_Visitor->visit(this);
 }

--- a/OrbitCore/LinuxPerfEventProcessor.h
+++ b/OrbitCore/LinuxPerfEventProcessor.h
@@ -52,7 +52,8 @@ class LinuxPerfEventProcessor {
   // are processed in the correct order.
   const uint64_t DELAY_IN_NS = 100000000 /*ns*/;
 
-  LinuxPerfEventProcessor(std::unique_ptr<LinuxPerfEventVisitor> a_Visitor)
+  explicit LinuxPerfEventProcessor(
+      std::unique_ptr<LinuxPerfEventVisitor> a_Visitor)
       : m_Visitor(std::move(a_Visitor)) {}
 
   void Push(std::unique_ptr<LinuxPerfEvent> a_Event);

--- a/OrbitCore/LinuxPerfEventVisitor.h
+++ b/OrbitCore/LinuxPerfEventVisitor.h
@@ -5,6 +5,7 @@
 //-----------------------------------
 // Author: Florian Kuebler
 //-----------------------------------
+
 #pragma once
 
 #include "LinuxPerfEvent.h"
@@ -22,4 +23,5 @@ class LinuxPerfEventVisitor {
   virtual void visit(LinuxUprobeEvent* a_Event) {}
   virtual void visit(LinuxUprobeEventWithStack* a_Event) {}
   virtual void visit(LinuxUretprobeEvent* a_Event) {}
+  virtual void visit(LinuxUretprobeEventWithStack* a_Event) {}
 };

--- a/OrbitCore/LinuxPerfRingBuffer.h
+++ b/OrbitCore/LinuxPerfRingBuffer.h
@@ -5,7 +5,9 @@
 //-----------------------------------
 // Author: Florian Kuebler
 //-----------------------------------
-#pragma once
+
+#ifndef ORBIT_CORE_PERF_RING_BUFFER_H_
+#define ORBIT_CORE_PERF_RING_BUFFER_H_
 
 #include <linux/perf_event.h>
 
@@ -17,15 +19,19 @@ class LinuxPerfRingBuffer {
  public:
   explicit LinuxPerfRingBuffer(uint32_t a_PerfFileDescriptor);
   ~LinuxPerfRingBuffer();
+
   LinuxPerfRingBuffer(LinuxPerfRingBuffer&&) noexcept;
   LinuxPerfRingBuffer& operator=(LinuxPerfRingBuffer&&) noexcept;
+
   LinuxPerfRingBuffer(const LinuxPerfRingBuffer&) = delete;
   LinuxPerfRingBuffer& operator=(const LinuxPerfRingBuffer&) = delete;
+
   bool HasNewData();
   void ReadHeader(perf_event_header* a_Header);
   void SkipRecord(const perf_event_header& a_Header);
 
-  //-----------------------------------------------------------------------------
+  uint32_t FileDescriptor() const { return m_FileDescriptor; }
+
   template <typename LinuxPerfEvent>
   LinuxPerfEvent ConsumeRecord(const perf_event_header& a_Header) {
     LinuxPerfEvent record;
@@ -56,7 +62,7 @@ class LinuxPerfRingBuffer {
   // http://man7.org/linux/man-pages/man2/perf_event_open.2.html
   const size_t MMAP_LENGTH = (1 + RING_BUFFER_PAGE_COUNT) * PAGE_SIZE;
 
-  uint32_t m_FileDescriptor = -1;
+  int32_t m_FileDescriptor = -1;
   perf_event_mmap_page* m_Metadata = nullptr;
   char* m_Buffer = nullptr;
   uint64_t m_BufferLength = 0;
@@ -67,3 +73,5 @@ class LinuxPerfRingBuffer {
 
   void* mmap_mapping(int32_t a_FileDescriptor);
 };
+
+#endif  // ORBIT_CORE_PERF_RING_BUFFER_H_

--- a/OrbitCore/LinuxPerfUtils.cpp
+++ b/OrbitCore/LinuxPerfUtils.cpp
@@ -17,8 +17,9 @@
 #include "PrintVar.h"
 #include "ScopeTimer.h"
 
-//-----------------------------------------------------------------------------
-perf_event_attr LinuxPerfUtils::generic_perf_event_attr() {
+namespace LinuxPerfUtils {
+namespace {
+perf_event_attr generic_event_attr() {
   perf_event_attr pe{};
   pe.size = sizeof(struct perf_event_attr);
   pe.sample_period = 1;
@@ -27,138 +28,107 @@ perf_event_attr LinuxPerfUtils::generic_perf_event_attr() {
   pe.sample_id_all = 1;  // also include timestamps for lost events
   pe.disabled = 1;
 
-  // we can set these even if we do not do sampling, as without the flag being
-  // set in sample_type, they won't be used anyways.
+  // We can set these even if we do not do sampling, as without the flag being
+  // set in sample_type they won't be used anyways.
   pe.sample_stack_user = SAMPLE_STACK_USER_SIZE;
   pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
 
-  pe.sample_type = SAMPLE_TYPE_FLAGS;
+  pe.sample_type = SAMPLE_TYPE_BASIC_FLAGS;
 
   return pe;
 }
 
-//-----------------------------------------------------------------------------
-int32_t LinuxPerfUtils::task_event_open(int32_t a_CPU) {
-  perf_event_attr pe = generic_perf_event_attr();
+int32_t generic_event_open(perf_event_attr* attr, pid_t pid, int32_t cpu) {
+  int32_t fd = perf_event_open(attr, pid, cpu, -1, 0);
+  if (fd == -1) {
+    PRINT("perf_event_open error: %s\n", strerror(errno));
+  }
+  return fd;
+}
+
+perf_event_attr uprobe_event_attr(const char* module,
+                                  uint64_t function_offset) {
+  perf_event_attr pe = generic_event_attr();
+
+  pe.type = 7;  // TODO: should be read from
+                //  "/sys/bus/event_source/devices/uprobe/type"
+  pe.config1 =
+      reinterpret_cast<uint64_t>(module);  // pe.config1 == pe.uprobe_path
+  pe.config2 = function_offset;            // pe.config2 == pe.probe_offset
+
+  return pe;
+}
+}  // namespace
+}  // namespace LinuxPerfUtils
+
+int32_t LinuxPerfUtils::task_event_open(int32_t cpu) {
+  perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_DUMMY;
   pe.task = 1;
 
-  int32_t fd = perf_event_open(&pe, -1, a_CPU, -1 /*group_fd*/, 0 /*flags*/);
-
-  if (fd == -1) {
-    PRINT("perf_event_open error: %s\n", strerror(errno));
-  }
-
-  return fd;
+  return generic_event_open(&pe, -1, cpu);
 }
 
-//-----------------------------------------------------------------------------
-int32_t LinuxPerfUtils::context_switch_open(pid_t a_PID, int32_t a_CPU) {
-  perf_event_attr pe = generic_perf_event_attr();
+int32_t LinuxPerfUtils::context_switch_open(pid_t pid, int32_t cpu) {
+  perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_DUMMY;
   pe.context_switch = 1;
 
-  int32_t fd = perf_event_open(&pe, a_PID, a_CPU, -1 /*group_fd*/, 0 /*flags*/);
-
-  if (fd == -1) {
-    PRINT("perf_event_open error: %s\n", strerror(errno));
-  }
-
-  return fd;
+  return generic_event_open(&pe, pid, cpu);
 }
 
-//-----------------------------------------------------------------------------
-int32_t LinuxPerfUtils::stack_sample_event_open(pid_t a_PID,
-                                                uint64_t a_Frequency) {
-  perf_event_attr pe = generic_perf_event_attr();
+int32_t LinuxPerfUtils::stack_sample_event_open(pid_t pid, uint64_t period_ns) {
+  perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_CPU_CLOCK;
-  pe.sample_freq = a_Frequency;
-  pe.freq = 1;
+  pe.sample_period = period_ns;
   pe.sample_type |= PERF_SAMPLE_STACK_USER | PERF_SAMPLE_REGS_USER;
   pe.task = 1;
   pe.mmap = 1;
 
-  int32_t fd = perf_event_open(&pe, a_PID, -1, -1, 0);
-
-  if (fd == -1) {
-    PRINT("perf_event_open error: %s\n", strerror(errno));
-  }
-
-  return fd;
+  return generic_event_open(&pe, pid, -1);
 }
 
-//-----------------------------------------------------------------------------
 bool LinuxPerfUtils::supports_perf_event_uprobes() {
   return LinuxUtils::GetKernelVersion() >= KERNEL_VERSION(4, 17, 0);
 }
 
-//-----------------------------------------------------------------------------
-int32_t LinuxPerfUtils::uprobe_event_open(const char* a_Module,
-                                          uint64_t a_FunctionOffset,
-                                          pid_t a_PID, int32_t a_CPU,
-                                          int32_t a_GroupFd,
-                                          uint64_t additonal_sample_type) {
-  SCOPE_TIMER_FUNC;
-  PRINT_VAR(a_Module);
-  PRINT_VAR(a_FunctionOffset);
-  PRINT_VAR(a_PID);
-  PRINT_VAR(a_CPU);
-  PRINT_VAR(a_GroupFd);
-  PRINT_VAR(additonal_sample_type);
-
-  perf_event_attr pe = generic_perf_event_attr();
-
-  pe.type = 7;  // TODO: should be read from
-                // "/sys/bus/event_source/devices/uprobe/type"
+int32_t LinuxPerfUtils::uprobe_event_open(const char* module,
+                                          uint64_t function_offset, pid_t pid,
+                                          int32_t cpu) {
+  perf_event_attr pe = uprobe_event_attr(module, function_offset);
   pe.config = 0;
-  pe.config1 =
-      reinterpret_cast<uint64_t>(a_Module);  // pe.config1 == pe.uprobe_path
-  pe.config2 = a_FunctionOffset;             // pe.config2 == pe.probe_offset
-  pe.sample_type |= additonal_sample_type;
 
-  int32_t fd = perf_event_open(&pe, a_PID, a_CPU, a_GroupFd, 0 /*flags*/);
-
-  if (fd == -1) {
-    PRINT("perf_event_open error: %s\n", strerror(errno));
-  }
-
-  PRINT_VAR(fd);
-  return fd;
+  return generic_event_open(&pe, pid, cpu);
 }
 
-//-----------------------------------------------------------------------------
-int32_t LinuxPerfUtils::uretprobe_event_open(const char* a_Module,
-                                             uint64_t a_FunctionOffset,
-                                             pid_t a_PID, int32_t a_CPU,
-                                             int32_t a_GroupFd,
-                                             uint64_t additonal_sample_type) {
-  SCOPE_TIMER_FUNC;
-  PRINT_VAR(a_Module);
-  PRINT_VAR(a_FunctionOffset);
-  PRINT_VAR(a_PID);
-  PRINT_VAR(a_CPU);
-  PRINT_VAR(a_GroupFd);
-  PRINT_VAR(additonal_sample_type);
+int32_t LinuxPerfUtils::uprobe_stack_event_open(const char* module,
+                                                uint64_t function_offset,
+                                                pid_t pid, int32_t cpu) {
+  perf_event_attr pe = uprobe_event_attr(module, function_offset);
+  pe.config = 0;
+  pe.sample_type |= PERF_SAMPLE_STACK_USER | PERF_SAMPLE_REGS_USER;
 
-  perf_event_attr pe = generic_perf_event_attr();
+  return generic_event_open(&pe, pid, cpu);
+}
 
-  pe.type = 7;  // TODO: should be read from
-                // "/sys/bus/event_source/devices/uprobe/type"
-  pe.config = 1;
-  pe.config1 =
-      reinterpret_cast<uint64_t>(a_Module);  // pe.config1 == pe.uprobe_path
-  pe.config2 = a_FunctionOffset;             // pe.config2 == pe.probe_offset
-  pe.sample_type |= additonal_sample_type;
+int32_t LinuxPerfUtils::uretprobe_event_open(const char* module,
+                                             uint64_t function_offset,
+                                             pid_t pid, int32_t cpu) {
+  perf_event_attr pe = uprobe_event_attr(module, function_offset);
+  pe.config = 1;  // Set bit 0 of config for uretprobe.
 
-  int32_t fd = perf_event_open(&pe, a_PID, a_CPU, a_GroupFd, 0 /*flags*/);
+  return generic_event_open(&pe, pid, cpu);
+}
 
-  if (fd == -1) {
-    PRINT("perf_event_open error: %s\n", strerror(errno));
-  }
+int32_t LinuxPerfUtils::uretprobe_stack_event_open(const char* module,
+                                                   uint64_t function_offset,
+                                                   pid_t pid, int32_t cpu) {
+  perf_event_attr pe = uprobe_event_attr(module, function_offset);
+  pe.config = 1;  // Set bit 0 of config for uretprobe.
+  pe.sample_type |= PERF_SAMPLE_STACK_USER | PERF_SAMPLE_REGS_USER;
 
-  PRINT_VAR(fd);
-  return fd;
+  return generic_event_open(&pe, pid, cpu);
 }

--- a/OrbitCore/LinuxPerfUtils.h
+++ b/OrbitCore/LinuxPerfUtils.h
@@ -5,7 +5,9 @@
 //-----------------------------------
 // Author: Florian Kuebler
 //-----------------------------------
-#pragma once
+
+#ifndef ORBIT_CORE_LINUX_PERF_UTILS_H_
+#define ORBIT_CORE_LINUX_PERF_UTILS_H_
 
 #include <asm/perf_regs.h>
 #include <asm/unistd.h>
@@ -18,27 +20,28 @@
 #include <cerrno>
 #include <cstdint>
 
-//-----------------------------------------------------------------------------
+inline int32_t perf_event_open(struct perf_event_attr* attr, pid_t pid,
+                               int32_t cpu, int32_t group_fd, uint64_t flags) {
+  return syscall(__NR_perf_event_open, attr, pid, cpu, group_fd, flags);
+}
+
 namespace LinuxPerfUtils {
 // This must be in sync with the struct perf_sample_id defined below.
-static constexpr uint64_t SAMPLE_TYPE_FLAGS =
+static constexpr uint64_t SAMPLE_TYPE_BASIC_FLAGS =
     PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CPU;
 
-// TODO: These constants should be made available in some settings.
+// TODO: As this amount of memory has to be copied from the ring buffer for each
+//  sample, this constant should be made available in some setting.
 // Max to pass to perf_event_open without getting an error is (1u << 16u) - 8,
 // because the kernel stores this in a short and because of alignment reasons.
-// But the size the kernel actually returns is smaller, because the maximum
-// size of the entire record the kernel is willing to return is (1u << 16u) - 8.
-// If we want the size we pass to coincide with the size we get, we need to
-// pass a lower value. For the current layout of perf_record_with_stack,
-// the maximum size is 65312, but let's leave some extra room.
+// But the size the kernel actually returns is smaller, because the maximum size
+// of the entire record the kernel is willing to return is (1u << 16u) - 8.
+// If we want the size we pass to coincide with the size we get, we need to pass
+// a lower value. For the current layout of perf_record_with_stack, the maximum
+// size is 65312, but let's leave some extra room.
 static constexpr uint16_t SAMPLE_STACK_USER_SIZE = 65000;
 
-// Sample stack pointer and instruction pointer only.
-static constexpr uint64_t SAMPLE_REGS_USER_SP_IP =
-    (1lu << PERF_REG_X86_SP) | (1lu << PERF_REG_X86_IP);
-
-// Sample all pointers: they might all be necessary later for DWARF-based stack
+// Sample all registers: they might all be necessary for DWARF-based stack
 // unwinding.
 static constexpr uint64_t SAMPLE_REGS_USER_ALL =
     (1lu << PERF_REG_X86_AX) | (1lu << PERF_REG_X86_BX) |
@@ -52,18 +55,12 @@ static constexpr uint64_t SAMPLE_REGS_USER_ALL =
     (1lu << PERF_REG_X86_R12) | (1lu << PERF_REG_X86_R13) |
     (1lu << PERF_REG_X86_R14) | (1lu << PERF_REG_X86_R15);
 
-// This struct must be in sync with the SAMPLE_TYPE_FLAGS, as the bits set
+// This struct must be in sync with the SAMPLE_TYPE_BASIC_FLAGS, as the bits set
 // in perf_event_attr::sample_type determine the fields this struct should have.
 struct perf_sample_id {
   uint32_t pid, tid; /* if PERF_SAMPLE_TID */
   uint64_t time;     /* if PERF_SAMPLE_TIME */
   uint32_t cpu, res; /* if PERF_SAMPLE_CPU */
-};
-
-struct perf_sample_regs_user_sp_ip {
-  uint64_t abi;
-  uint64_t sp;
-  uint64_t ip;
 };
 
 struct perf_sample_regs_user_all {
@@ -89,18 +86,12 @@ struct perf_sample_regs_user_all {
   uint64_t r14;
   uint64_t r15;
 };
+
 struct perf_sample_stack_user {
   uint64_t size;                     /* if PERF_SAMPLE_STACK_USER */
   char data[SAMPLE_STACK_USER_SIZE]; /* if PERF_SAMPLE_STACK_USER */
   uint64_t dyn_size; /* if PERF_SAMPLE_STACK_USER && size != 0 */
 };
-
-inline int32_t perf_event_open(struct perf_event_attr* a_HWEvent, pid_t a_PID,
-                               int32_t a_CPU, int32_t a_GroupFD,
-                               uint32_t a_Flags) {
-  return syscall(__NR_perf_event_open, a_HWEvent, a_PID, a_CPU, a_GroupFD,
-                 a_Flags);
-}
 
 inline void start_capturing(uint32_t a_FileDescriptor) {
   ioctl(a_FileDescriptor, PERF_EVENT_IOC_RESET, 0);
@@ -111,28 +102,34 @@ inline void stop_capturing(uint32_t a_FileDescriptor) {
   ioctl(a_FileDescriptor, PERF_EVENT_IOC_DISABLE, 0);
 }
 
-perf_event_attr generic_perf_event_attr();
-
 // perf_event_open for fork and exit.
-int32_t task_event_open(int32_t a_CPU);
+int32_t task_event_open(int32_t cpu);
 
 // perf_event_open for context switches.
-int32_t context_switch_open(pid_t a_PID, int32_t a_CPU);
+int32_t context_switch_open(pid_t pid, int32_t cpu);
 
 // perf_event_open for kernel tracepoints.
 int32_t tracepoint_event_open(uint64_t a_TracepointID, pid_t a_PID,
                               int32_t a_CPU,
                               uint64_t additional_sample_type = 0);
 
-// perf_event_open for stack sampling
-int32_t stack_sample_event_open(pid_t a_PID, uint64_t a_Frequency);
+// perf_event_open for stack sampling.
+int32_t stack_sample_event_open(pid_t pid, uint64_t period_ns);
 
 // perf_event_open for uprobes.
 bool supports_perf_event_uprobes();
-int32_t uprobe_event_open(const char* a_Module, uint64_t a_FunctionOffset,
-                          pid_t a_PID, int32_t a_CPU, int32_t a_GroupFd = -1,
-                          uint64_t additonal_sample_type = 0);
-int32_t uretprobe_event_open(const char* a_Module, uint64_t a_FunctionOffset,
-                             pid_t a_PID, int32_t a_CPU, int32_t a_GroupFd = -1,
-                             uint64_t additonal_sample_type = 0);
+
+int32_t uprobe_event_open(const char* module, uint64_t function_offset,
+                          pid_t pid, int32_t cpu);
+
+int32_t uprobe_stack_event_open(const char* module, uint64_t function_offset,
+                                pid_t pid, int32_t cpu);
+
+int32_t uretprobe_event_open(const char* module, uint64_t function_offset,
+                             pid_t pid, int32_t cpu);
+
+int32_t uretprobe_stack_event_open(const char* module, uint64_t function_offset,
+                                   pid_t pid, int32_t cpu);
 }  // namespace LinuxPerfUtils
+
+#endif  // ORBIT_CORE_LINUX_PERF_UTILS_H_

--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -29,7 +29,7 @@ Params::Params()
       m_AutoReleasePdb(false),
       m_BpftraceCallstacks(false),
       m_SystemWideScheduling(true),
-      m_UseBpftrace(true),
+      m_UseBpftrace(false),
       m_SampleWithPerf(false),
       m_MaxNumTimers(1000000),
       m_FontSize(14.f),

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1014,8 +1014,10 @@ void OrbitApp::StartCapture() {
   if (Capture::StartCapture() && !Capture::IsRemote()) {
     // TODO: Either we remove BpfTrace soon, or we should use it from a
     //  single code location (the other one is in ConnectionManager.h/.cpp)
-    m_BpfTrace = std::make_shared<BpfTrace>();
-    m_BpfTrace->Start();
+    if (GParams.m_UseBpftrace) {
+      m_BpfTrace = std::make_shared<BpfTrace>();
+      m_BpfTrace->Start();
+    }
   }
 #endif
 


### PR DESCRIPTION
Replace BpfTrace with perf_event_open for dynamic instrumentation, still using
u(ret)probes under the hood.
Also get a stack sample at the beginning and end of a dynamically-instrumented
function.

Note that stack unwinding is currently broken when a time-based sample falls
inside a dynamically-instrumented function, because of how uretprobes work.
This is not a direct cause of this change as it also happens with BpfTrace.
We have a possible fix in mind for this that will come later.