### PR TITLE
Fix CLion workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ cmake_minimum_required(VERSION 3.15)
 # with https://github.com/Microsoft/vcpkg/blob/master/docs/examples/using-
 # sqlite.md#cmake
 
+set(CMAKE_TOOLCHAIN_FILE
+    "${CMAKE_CURRENT_LIST_DIR}/external/vcpkg/scripts/buildsystems/vcpkg.cmake"
+    CACHE STRING "Default CMake toolchain file")
+
 project(Orbit C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")


### PR DESCRIPTION
CLion's handles toolchains internally and passes its configuration on to cmake via defines or environment variables.

To make this work with our build setup, we have to load the vcpkg toolchain file in case none is given by the user.

This is what's happening in this commit. By setting a variable with the "CACHE" option, it means it's only set when there is no predefined value.