### PR TITLE
Make unwinding of samples falling inside uprobes-instrumented functions work

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -26,7 +26,7 @@ Check out the `bootstrap-orbit.{sh, bat}` file for a general description on how
 to install dependencies and on how to set up a `build/`-directory.
 
 
-## Consistent code styling.
+## Consistent code styling
 
 We use `clang-format` to achieve a consistent code styling across
 the whole code base. You need at least version 7.0.0 of `clang-format`.

--- a/OrbitAsm/OrbitAsm.cpp
+++ b/OrbitAsm/OrbitAsm.cpp
@@ -1,8 +1,8 @@
 #include "OrbitAsm.h"
 
+#include <cstdint>
 #include <sstream>
 #include <vector>
-#include <cstdint>
 
 OrbitProlog GProlog;
 OrbitEpilog GEpilog;
@@ -10,9 +10,9 @@ OrbitEpilog GEpilog;
 //-----------------------------------------------------------------------------
 #ifdef _WIN64
 std::vector<std::uint8_t> dummyEnd = {0x49, 0xBB, 0xFF, 0xFF, 0xFF,
-                              0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
+                                      0xFF, 0xFF, 0xFF, 0xFF, 0x0F};
 std::vector<std::uint8_t> dummyAddress = {0xEF, 0xCD, 0xAB, 0x89,
-                                  0x67, 0x45, 0x23, 0x01};
+                                          0x67, 0x45, 0x23, 0x01};
 #else
 std::vector<std::uint8_t> dummyEnd = {0xB8, 0xFF, 0xFF, 0xFF, 0x0F};
 std::vector<std::uint8_t> dummyAddress = {0x78, 0x56, 0x34, 0x12};

--- a/OrbitAsm/OrbitAsmC.h
+++ b/OrbitAsm/OrbitAsmC.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 //-----------------------------------------------------------------------------
 enum OrbitPrologOffset {

--- a/OrbitCore/BpfTraceVisitor.cpp
+++ b/OrbitCore/BpfTraceVisitor.cpp
@@ -37,6 +37,7 @@ void BpfTraceVisitor::visit(LinuxUprobeEventWithStack* a_Event) {
   m_TimerStacks[a_Event->TID()].push_back(timer);
 }
 
+// TODO: Here, we would also like to handle the callstack
 void BpfTraceVisitor::visit(LinuxUretprobeEventWithStack* a_Event) {
   std::vector<Timer>& timers = m_TimerStacks[a_Event->TID()];
   if (!timers.empty()) {

--- a/OrbitCore/BpfTraceVisitor.h
+++ b/OrbitCore/BpfTraceVisitor.h
@@ -13,5 +13,5 @@ class BpfTraceVisitor : public LinuxPerfEventVisitor {
   void visit(LinuxUretprobeEventWithStack* a_Event) override;
 
  private:
-  std::map<uint64_t, std::vector<Timer>> m_TimerStacks;
+  std::map<pid_t, std::vector<Timer>> m_TimerStacks;
 };

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -205,7 +205,8 @@ target_compile_features(OrbitCore PUBLIC cxx_std_11)
 add_executable(OrbitCoreTests)
 
 target_sources(OrbitCoreTests
-  PRIVATE RingBufferTests.cpp)
+  PRIVATE LinuxUprobesUnwindingVisitorTests.cpp
+          RingBufferTests.cpp)
 
 target_link_libraries(
   OrbitCoreTests PRIVATE OrbitCore GTest::GTest GTest::Main)

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -151,25 +151,27 @@ else()
     OrbitCore
     PUBLIC BpfTraceVisitor.h
            BpfTrace.h
-           LinuxUtils.h
+           LibunwindstackUnwinder.h
+           LinuxEventTracer.h
            LinuxPerfEvent.h
-           LinuxPerfEventVisitor.h
            LinuxPerfEventProcessor.h
+           LinuxPerfEventVisitor.h
            LinuxPerfRingBuffer.h
            LinuxPerfUtils.h
-           LibunwindstackUnwinder.h
-           LinuxEventTracer.h)
+           LinuxUprobesUnwindingVisitor.h
+           LinuxUtils.h)
 
   target_sources(
     OrbitCore
     PRIVATE BpfTraceVisitor.cpp
             LibunwindstackUnwinder.cpp
+            LinuxEventTracer.cpp
             LinuxUtils.cpp
             LinuxPerfEvent.cpp
+            LinuxPerfEventProcessor.cpp
             LinuxPerfRingBuffer.cpp
             LinuxPerfUtils.cpp
-            LinuxEventTracer.cpp
-            LinuxPerfEventProcessor.cpp)
+            LinuxUprobesUnwindingVisitor.cpp)
 endif()
 
 target_include_directories(OrbitCore PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -19,6 +19,10 @@ struct ContextSwitch {
   uint16_t m_ProcessorIndex;
   uint8_t m_ProcessorNumber;
 
+  // TODO: The distinction between m_ProcessorIndex and m_ProcessorNumber is Windows-specific. Consider removing m_ProcessorNumber.
+  //  See https://docs.microsoft.com/en-us/windows/win32/api/relogger/ns-relogger-etw_buffer_context
+  //  and EVENT_HEADER_FLAG_PROCESSOR_INDEX in https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/fa4f7836-06ee-4ab6-8688-386a5a85f8c5
+
   ORBIT_SERIALIZABLE;
 };
 #pragma pack(pop)

--- a/OrbitCore/ContextSwitch.h
+++ b/OrbitCore/ContextSwitch.h
@@ -19,9 +19,12 @@ struct ContextSwitch {
   uint16_t m_ProcessorIndex;
   uint8_t m_ProcessorNumber;
 
-  // TODO: The distinction between m_ProcessorIndex and m_ProcessorNumber is Windows-specific. Consider removing m_ProcessorNumber.
-  //  See https://docs.microsoft.com/en-us/windows/win32/api/relogger/ns-relogger-etw_buffer_context
-  //  and EVENT_HEADER_FLAG_PROCESSOR_INDEX in https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/fa4f7836-06ee-4ab6-8688-386a5a85f8c5
+  // TODO: The distinction between m_ProcessorIndex and m_ProcessorNumber is
+  //  Windows-specific. Consider removing m_ProcessorNumber.
+  // See
+  // https://docs.microsoft.com/en-us/windows/win32/api/relogger/ns-relogger-etw_buffer_context
+  // and EVENT_HEADER_FLAG_PROCESSOR_INDEX in
+  // https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/fa4f7836-06ee-4ab6-8688-386a5a85f8c5
 
   ORBIT_SERIALIZABLE;
 };

--- a/OrbitCore/Hijacking.cpp
+++ b/OrbitCore/Hijacking.cpp
@@ -8,7 +8,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "OrbitAsm.h"
 #include "../external/minhook/src/buffer.h"
 #include "../external/minhook/src/trampoline.h"
 #include "Callstack.h"
@@ -16,6 +15,7 @@
 #include "Core.h"
 #include "Message.h"
 #include "MinHook.h"
+#include "OrbitAsm.h"
 #include "OrbitLib.h"
 #include "OrbitType.h"
 #include "ScopeTimer.h"

--- a/OrbitCore/LinuxCallstackEvent.cpp
+++ b/OrbitCore/LinuxCallstackEvent.cpp
@@ -5,6 +5,7 @@
 //-----------------------------------
 // Author: Florian Kuebler
 //-----------------------------------
+
 #include "LinuxCallstackEvent.h"
 
 #include "Serialization.h"

--- a/OrbitCore/LinuxEventTracer.cpp
+++ b/OrbitCore/LinuxEventTracer.cpp
@@ -220,7 +220,7 @@ void LinuxEventTracerThread::Run(
             // This should happen rarely.
             ring_buffer.SkipRecord(header);
             uprobe_event_processor.Push(std::make_unique<LinuxMapsEvent>(
-                LinuxPerfUtils::GetClockRealtime(),
+                OrbitTicks(CLOCK_MONOTONIC),
                 LinuxUtils::ReadMaps(pid_)));
           } break;
 

--- a/OrbitCore/LinuxEventTracer.h
+++ b/OrbitCore/LinuxEventTracer.h
@@ -14,7 +14,6 @@
 #include <thread>
 #include <utility>
 
-#include "CallstackTypes.h"
 #include "LibunwindstackUnwinder.h"
 #include "OrbitFunction.h"
 #include "PrintVar.h"
@@ -48,8 +47,6 @@ class LinuxEventTracerThread {
 
   bool ComputeSamplingPeriodNs();
   void LoadNumCpus();
-  static void HandleCallstack(pid_t tid, uint64_t timestamp,
-                              const std::vector<unwindstack::FrameData>& frames);
 };
 
 class LinuxEventTracer {
@@ -58,7 +55,8 @@ class LinuxEventTracer {
 
   LinuxEventTracer(pid_t pid, double sampling_frequency,
                    std::vector<Function*> instrumented_functions)
-      : pid_{pid}, sampling_frequency_{sampling_frequency},
+      : pid_{pid},
+        sampling_frequency_{sampling_frequency},
         instrumented_functions_{std::move(instrumented_functions)} {}
 
   explicit LinuxEventTracer(pid_t pid)
@@ -84,8 +82,8 @@ class LinuxEventTracer {
     PRINT_FUNC;
     *exit_requested_ = false;
     thread_ = std::make_shared<std::thread>(
-        &LinuxEventTracer::Run,
-        pid_, sampling_frequency_, instrumented_functions_, exit_requested_);
+        &LinuxEventTracer::Run, pid_, sampling_frequency_,
+        instrumented_functions_, exit_requested_);
     thread_->detach();
   }
 
@@ -106,8 +104,8 @@ class LinuxEventTracer {
   static void Run(pid_t pid, double sampling_frequency,
                   const std::vector<Function*>& instrumented_functions,
                   const std::shared_ptr<std::atomic<bool>>& exit_requested) {
-    LinuxEventTracerThread{pid, sampling_frequency, instrumented_functions}
-        .Run(exit_requested);
+    LinuxEventTracerThread{pid, sampling_frequency, instrumented_functions}.Run(
+        exit_requested);
   }
 };
 

--- a/OrbitCore/LinuxPerfEvent.cpp
+++ b/OrbitCore/LinuxPerfEvent.cpp
@@ -14,43 +14,46 @@
 // LinuxPerfEventVisitor needs to be an incomplete type to avoid the circular
 // dependency between LinuxPerfEvent.h and LinuxPerfEventVisitor.h.
 
-void LinuxPerfLostEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxPerfLostEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxForkEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxForkEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxExitEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxExitEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxContextSwitchEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxContextSwitchEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxSystemWideContextSwitchEvent::accept(
-    LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxSystemWideContextSwitchEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxStackSampleEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxStackSampleEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxUprobeEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxUprobeEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxUprobeEventWithStack::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxUprobeEventWithStack::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxUretprobeEvent::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxUretprobeEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }
 
-void LinuxUretprobeEventWithStack::accept(LinuxPerfEventVisitor* a_Visitor) {
-  a_Visitor->visit(this);
+void LinuxUretprobeEventWithStack::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
+}
+
+void LinuxMapsEvent::accept(LinuxPerfEventVisitor* visitor) {
+  visitor->visit(this);
 }

--- a/OrbitCore/LinuxPerfEvent.h
+++ b/OrbitCore/LinuxPerfEvent.h
@@ -28,7 +28,7 @@ class LinuxPerfEventVisitor;
 
 class LinuxPerfEvent {
  public:
-  virtual uint64_t Timestamp() = 0;
+  virtual uint64_t Timestamp() const = 0;
   virtual void accept(LinuxPerfEventVisitor* a_Visitor) = 0;
 };
 
@@ -41,17 +41,19 @@ class LinuxContextSwitchEvent : public LinuxPerfEvent {
  public:
   perf_context_switch_event ring_buffer_data{};
 
-  uint64_t Timestamp() override { return ring_buffer_data.sample_id.time; }
+  uint64_t Timestamp() const override {
+    return ring_buffer_data.sample_id.time;
+  }
 
   void accept(LinuxPerfEventVisitor* a_Visitor) override;
 
-  pid_t PID() { return ring_buffer_data.sample_id.pid; }
-  pid_t TID() { return ring_buffer_data.sample_id.tid; }
-  uint32_t CPU() { return ring_buffer_data.sample_id.cpu; }
-  bool IsSwitchOut() {
+  pid_t PID() const { return ring_buffer_data.sample_id.pid; }
+  pid_t TID() const { return ring_buffer_data.sample_id.tid; }
+  uint32_t CPU() const { return ring_buffer_data.sample_id.cpu; }
+  bool IsSwitchOut() const {
     return ring_buffer_data.header.misc & PERF_RECORD_MISC_SWITCH_OUT;
   }
-  bool IsSwitchIn() { return !IsSwitchOut(); }
+  bool IsSwitchIn() const { return !IsSwitchOut(); }
 };
 
 struct __attribute__((__packed__)) perf_context_switch_cpu_wide_event {
@@ -65,37 +67,39 @@ class LinuxSystemWideContextSwitchEvent : public LinuxPerfEvent {
  public:
   perf_context_switch_cpu_wide_event ring_buffer_data{};
 
-  uint64_t Timestamp() override { return ring_buffer_data.sample_id.time; }
+  uint64_t Timestamp() const override {
+    return ring_buffer_data.sample_id.time;
+  }
 
   void accept(LinuxPerfEventVisitor* a_Visitor) override;
 
-  pid_t PrevPID() {
+  pid_t PrevPID() const {
     return IsSwitchOut() ? ring_buffer_data.sample_id.pid
                          : ring_buffer_data.next_prev_pid;
   }
 
-  pid_t PrevTID() {
+  pid_t PrevTID() const {
     return IsSwitchOut() ? ring_buffer_data.sample_id.tid
                          : ring_buffer_data.next_prev_tid;
   }
 
-  pid_t NextPID() {
+  pid_t NextPID() const {
     return IsSwitchOut() ? ring_buffer_data.next_prev_pid
                          : ring_buffer_data.sample_id.pid;
   }
 
-  pid_t NextTID() {
+  pid_t NextTID() const {
     return IsSwitchOut() ? ring_buffer_data.next_prev_tid
                          : ring_buffer_data.sample_id.tid;
   }
 
-  bool IsSwitchOut() {
+  bool IsSwitchOut() const {
     return ring_buffer_data.header.misc & PERF_RECORD_MISC_SWITCH_OUT;
   }
 
-  bool IsSwitchIn() { return !IsSwitchOut(); }
+  bool IsSwitchIn() const { return !IsSwitchOut(); }
 
-  uint32_t CPU() { return ring_buffer_data.sample_id.cpu; }
+  uint32_t CPU() const { return ring_buffer_data.sample_id.cpu; }
 };
 
 struct __attribute__((__packed__)) perf_fork_exit_event {
@@ -110,28 +114,28 @@ class LinuxForkEvent : public LinuxPerfEvent {
  public:
   perf_fork_exit_event ring_buffer_data{};
 
-  uint64_t Timestamp() override { return ring_buffer_data.time; }
+  uint64_t Timestamp() const override { return ring_buffer_data.time; }
 
   void accept(LinuxPerfEventVisitor* a_Visitor) override;
 
-  pid_t PID() { return ring_buffer_data.pid; }
-  pid_t ParentPID() { return ring_buffer_data.ppid; }
-  pid_t TID() { return ring_buffer_data.tid; }
-  pid_t ParentTID() { return ring_buffer_data.ptid; }
+  pid_t PID() const { return ring_buffer_data.pid; }
+  pid_t ParentPID() const { return ring_buffer_data.ppid; }
+  pid_t TID() const { return ring_buffer_data.tid; }
+  pid_t ParentTID() const { return ring_buffer_data.ptid; }
 };
 
 class LinuxExitEvent : public LinuxPerfEvent {
  public:
   perf_fork_exit_event ring_buffer_data{};
 
-  uint64_t Timestamp() override { return ring_buffer_data.time; }
+  uint64_t Timestamp() const override { return ring_buffer_data.time; }
 
   void accept(LinuxPerfEventVisitor* a_Visitor) override;
 
-  pid_t PID() { return ring_buffer_data.pid; }
-  pid_t ParentPID() { return ring_buffer_data.ppid; }
-  pid_t TID() { return ring_buffer_data.tid; }
-  pid_t ParentTID() { return ring_buffer_data.ptid; }
+  pid_t PID() const { return ring_buffer_data.pid; }
+  pid_t ParentPID() const { return ring_buffer_data.ppid; }
+  pid_t TID() const { return ring_buffer_data.tid; }
+  pid_t ParentTID() const { return ring_buffer_data.ptid; }
 };
 
 struct __attribute__((__packed__)) perf_lost_event {
@@ -145,11 +149,13 @@ class LinuxPerfLostEvent : public LinuxPerfEvent {
  public:
   perf_lost_event ring_buffer_data{};
 
-  uint64_t Timestamp() override { return ring_buffer_data.sample_id.time; }
+  uint64_t Timestamp() const override {
+    return ring_buffer_data.sample_id.time;
+  }
 
   void accept(LinuxPerfEventVisitor* a_Visitor) override;
 
-  uint64_t Lost() { return ring_buffer_data.lost; }
+  uint64_t Lost() const { return ring_buffer_data.lost; }
 };
 
 template <typename perf_record_data_t>
@@ -157,13 +163,13 @@ class LinuxPerfEventRecord : public LinuxPerfEvent {
  public:
   perf_record_data_t ring_buffer_data;
 
-  uint64_t Timestamp() override {
+  uint64_t Timestamp() const override {
     return ring_buffer_data.basic_sample_data.time;
   }
 
-  pid_t PID() { return ring_buffer_data.basic_sample_data.pid; }
-  pid_t TID() { return ring_buffer_data.basic_sample_data.tid; }
-  uint32_t CPU() { return ring_buffer_data.basic_sample_data.cpu; }
+  pid_t PID() const { return ring_buffer_data.basic_sample_data.pid; }
+  pid_t TID() const { return ring_buffer_data.basic_sample_data.tid; }
+  uint32_t CPU() const { return ring_buffer_data.basic_sample_data.cpu; }
 };
 
 struct __attribute__((__packed__)) perf_empty_record {
@@ -215,62 +221,80 @@ perf_sample_regs_user_all_to_register_array(
 class LinuxStackSampleEvent
     : public LinuxPerfEventRecord<perf_record_with_stack> {
  public:
-  std::array<uint64_t, PERF_REG_X86_64_MAX> Registers() {
+  std::array<uint64_t, PERF_REG_X86_64_MAX> Registers() const {
     return perf_sample_regs_user_all_to_register_array(
         ring_buffer_data.register_data);
   }
 
-  const char* StackDump() { return ring_buffer_data.stack_data.data; }
-  uint64_t StackSize() { return ring_buffer_data.stack_data.dyn_size; }
+  const char* StackDump() const { return ring_buffer_data.stack_data.data; }
+  uint64_t StackSize() const { return ring_buffer_data.stack_data.dyn_size; }
 
-  void accept(LinuxPerfEventVisitor* a_Visitor) override;
+  void accept(LinuxPerfEventVisitor* visitor) override;
 };
 
 template <typename perf_record_data_t>
 class AbstractLinuxUprobeEvent
     : public LinuxPerfEventRecord<perf_record_data_t> {
  public:
-  Function* GetFunction() { return m_Function; }
-  void SetFunction(Function* a_Function) { m_Function = a_Function; }
+  Function* GetFunction() const { return function_; }
+  void SetFunction(Function* function) { function_ = function; }
 
  private:
-  Function* m_Function = nullptr;
+  Function* function_ = nullptr;
 };
 
 class LinuxUprobeEvent : public AbstractLinuxUprobeEvent<perf_empty_record> {
  public:
-  void accept(LinuxPerfEventVisitor* a_Visitor) override;
+  void accept(LinuxPerfEventVisitor* visitor) override;
 };
 
 class LinuxUprobeEventWithStack
     : public AbstractLinuxUprobeEvent<perf_record_with_stack> {
  public:
-  std::array<uint64_t, PERF_REG_X86_64_MAX> Registers() {
+  std::array<uint64_t, PERF_REG_X86_64_MAX> Registers() const {
     return perf_sample_regs_user_all_to_register_array(
         ring_buffer_data.register_data);
   }
 
-  const char* StackDump() { return ring_buffer_data.stack_data.data; }
-  uint64_t StackSize() { return ring_buffer_data.stack_data.dyn_size; }
+  const char* StackDump() const { return ring_buffer_data.stack_data.data; }
+  uint64_t StackSize() const { return ring_buffer_data.stack_data.dyn_size; }
 
-  void accept(LinuxPerfEventVisitor* a_Visitor) override;
+  void accept(LinuxPerfEventVisitor* visitor) override;
 };
 
 class LinuxUretprobeEvent : public AbstractLinuxUprobeEvent<perf_empty_record> {
  public:
-  void accept(LinuxPerfEventVisitor* a_Visitor) override;
+  void accept(LinuxPerfEventVisitor* visitor) override;
 };
 
 class LinuxUretprobeEventWithStack
     : public AbstractLinuxUprobeEvent<perf_record_with_stack> {
  public:
-  std::array<uint64_t, PERF_REG_X86_64_MAX> Registers() {
+  std::array<uint64_t, PERF_REG_X86_64_MAX> Registers() const {
     return perf_sample_regs_user_all_to_register_array(
         ring_buffer_data.register_data);
   }
 
-  const char* StackDump() { return ring_buffer_data.stack_data.data; }
-  uint64_t StackSize() { return ring_buffer_data.stack_data.dyn_size; }
+  const char* StackDump() const { return ring_buffer_data.stack_data.data; }
+  uint64_t StackSize() const { return ring_buffer_data.stack_data.dyn_size; }
 
-  void accept(LinuxPerfEventVisitor* a_Visitor) override;
+  void accept(LinuxPerfEventVisitor* visitor) override;
+};
+
+// This carries a snapshot of /proc/<pid>/maps and does not reflect a
+// perf_event_open event, but we want it to be part of the same hierarchy.
+class LinuxMapsEvent : public LinuxPerfEvent {
+ public:
+  LinuxMapsEvent(uint64_t timestamp, std::string maps)
+      : timestamp_{timestamp}, maps_{std::move(maps)} {}
+
+  uint64_t Timestamp() const override { return timestamp_; }
+
+  const std::string& Maps() const { return maps_; }
+
+  void accept(LinuxPerfEventVisitor* visitor) override;
+
+ private:
+  uint64_t timestamp_;
+  std::string maps_;
 };

--- a/OrbitCore/LinuxPerfEventProcessor.cpp
+++ b/OrbitCore/LinuxPerfEventProcessor.cpp
@@ -10,10 +10,13 @@
 
 #include <queue>
 
+#include "Profiling.h"
+
 void LinuxPerfEventProcessor::Push(std::unique_ptr<LinuxPerfEvent> event) {
 #ifndef NDEBUG
   if (last_processed_timestamp_ > 0 &&
-      event->Timestamp() < last_processed_timestamp_ - DELAY_NS) {
+      event->Timestamp() <
+          last_processed_timestamp_ - PROCESSING_DELAY_MS * 1'000'000) {
     PRINT("Error: processed an event out of order.\n");
   }
 #endif
@@ -35,13 +38,13 @@ void LinuxPerfEventProcessor::ProcessAllEvents() {
 }
 
 void LinuxPerfEventProcessor::ProcessOldEvents() {
-  uint64_t max_timestamp = LinuxPerfUtils::GetClockRealtime();
+  uint64_t max_timestamp = OrbitTicks(CLOCK_MONOTONIC);
 
   while (!event_queue_.empty()) {
     LinuxPerfEvent* event = event_queue_.top().get();
 
     // Do not read the most recent events are out-of-order events could arrive.
-    if (event->Timestamp() + DELAY_NS >= max_timestamp) {
+    if (event->Timestamp() + PROCESSING_DELAY_MS * 1'000'000 >= max_timestamp) {
       break;
     }
     event->accept(visitor_.get());

--- a/OrbitCore/LinuxPerfEventProcessor.cpp
+++ b/OrbitCore/LinuxPerfEventProcessor.cpp
@@ -10,42 +10,46 @@
 
 #include <queue>
 
-void LinuxPerfEventProcessor::Push(std::unique_ptr<LinuxPerfEvent> a_Event) {
-  const uint64_t timestamp = a_Event->Timestamp();
+void LinuxPerfEventProcessor::Push(std::unique_ptr<LinuxPerfEvent> event) {
 #ifndef NDEBUG
-  if (m_LastProcessTimestamp > 0 &&
-      timestamp < m_LastProcessTimestamp - DELAY_IN_NS)
+  if (last_processed_timestamp_ > 0 &&
+      event->Timestamp() < last_processed_timestamp_ - DELAY_NS) {
     PRINT("Error: processed an event out of order.\n");
+  }
 #endif
 
-  if (timestamp > m_MaxTimestamp) m_MaxTimestamp = timestamp;
-
-  m_EventQueue.push(std::move(a_Event));
+  event_queue_.push(std::move(event));
 }
 
-void LinuxPerfEventProcessor::ProcessAll() {
-  while (!m_EventQueue.empty()) {
-    LinuxPerfEvent* event = m_EventQueue.top().get();
-    event->accept(m_Visitor.get());
+void LinuxPerfEventProcessor::ProcessAllEvents() {
+  while (!event_queue_.empty()) {
+    LinuxPerfEvent* event = event_queue_.top().get();
+    event->accept(visitor_.get());
+
 #ifndef NDEBUG
-    m_LastProcessTimestamp = event->Timestamp();
+    last_processed_timestamp_ = event->Timestamp();
 #endif
-    m_EventQueue.pop();
+
+    event_queue_.pop();
   }
 }
 
-void LinuxPerfEventProcessor::ProcessTillOffset() {
-  // Process the events in the event_queue
-  while (!m_EventQueue.empty()) {
-    LinuxPerfEvent* event = m_EventQueue.top().get();
+void LinuxPerfEventProcessor::ProcessOldEvents() {
+  uint64_t max_timestamp = LinuxPerfUtils::GetClockRealtime();
 
-    // We should not read all events, otherwise we could miss events
-    // close to the max timestamp in the queue.
-    if (event->Timestamp() + DELAY_IN_NS > m_MaxTimestamp) break;
-    event->accept(m_Visitor.get());
+  while (!event_queue_.empty()) {
+    LinuxPerfEvent* event = event_queue_.top().get();
+
+    // Do not read the most recent events are out-of-order events could arrive.
+    if (event->Timestamp() + DELAY_NS >= max_timestamp) {
+      break;
+    }
+    event->accept(visitor_.get());
+
 #ifndef NDEBUG
-    m_LastProcessTimestamp = event->Timestamp();
+    last_processed_timestamp_ = event->Timestamp();
 #endif
-    m_EventQueue.pop();
+
+    event_queue_.pop();
   }
 }

--- a/OrbitCore/LinuxPerfEventProcessor.h
+++ b/OrbitCore/LinuxPerfEventProcessor.h
@@ -31,15 +31,16 @@ class TimestampReverseCompare {
 // them in order (oldest first). In other words, it synchronizes events from all
 // ring buffers according to their timestamps.
 // Its implementation builds on the assumption that we never expect events with
-// a timestamp older than DELAY_NS to be added. By not processing events that
-// are not older than this delay, we will never process events out of order.
+// a timestamp older than PROCESSING_DELAY_MS to be added. By not processing
+// events that are not older than this delay, we will never process events out
+// of order.
 class LinuxPerfEventProcessor {
  public:
   // Do not process events that are more recent than 0.1 seconds. There could be
   // events coming out of order as they are read from different perf_event_open
   // ring buffers and this ensure that all events are processed in the correct
   // order.
-  static constexpr uint64_t DELAY_NS = 100'000'000;
+  static constexpr uint64_t PROCESSING_DELAY_MS = 100;
 
   explicit LinuxPerfEventProcessor(
       std::unique_ptr<LinuxPerfEventVisitor> visitor)

--- a/OrbitCore/LinuxPerfEventVisitor.h
+++ b/OrbitCore/LinuxPerfEventVisitor.h
@@ -24,4 +24,5 @@ class LinuxPerfEventVisitor {
   virtual void visit(LinuxUprobeEventWithStack* a_Event) {}
   virtual void visit(LinuxUretprobeEvent* a_Event) {}
   virtual void visit(LinuxUretprobeEventWithStack* a_Event) {}
+  virtual void visit(LinuxMapsEvent* a_Event) {}
 };

--- a/OrbitCore/LinuxPerfRingBuffer.cpp
+++ b/OrbitCore/LinuxPerfRingBuffer.cpp
@@ -103,10 +103,12 @@ void LinuxPerfRingBuffer::Read(uint8_t* a_Destination, uint64_t a_Count) {
       exponent;
 
   if (a_Count > m_BufferLength) {
+    PRINT("Error: reading more than the size of the ring buffer\n");
+  } else if (m_Metadata->data_head > m_Metadata->data_tail + m_BufferLength) {
     // If mmap has been called with PROT_WRITE and
     // perf_event_mmap_page::data_tail is used properly, this should not happen,
     // as the kernel would not overwrite unread data.
-    PRINT("Error %u: too slow reading from the ring buffer\n", stderr);
+    PRINT("Error: too slow reading from the ring buffer\n");
   } else if (index_div_length == index_count_div_length) {
     memcpy(a_Destination, m_Buffer + modulo, a_Count);
   } else if (index_div_length == (index + a_Count - 1) / m_BufferLength - 1) {

--- a/OrbitCore/LinuxPerfRingBuffer.cpp
+++ b/OrbitCore/LinuxPerfRingBuffer.cpp
@@ -16,7 +16,7 @@
 #include "LinuxPerfUtils.h"
 #include "PrintVar.h"
 
-LinuxPerfRingBuffer::LinuxPerfRingBuffer(uint32_t a_PerfFileDescriptor) {
+LinuxPerfRingBuffer::LinuxPerfRingBuffer(int a_PerfFileDescriptor) {
   m_FileDescriptor = a_PerfFileDescriptor;
   void* mmap_ret = mmap_mapping(m_FileDescriptor);
 

--- a/OrbitCore/LinuxPerfRingBuffer.h
+++ b/OrbitCore/LinuxPerfRingBuffer.h
@@ -17,7 +17,7 @@
 
 class LinuxPerfRingBuffer {
  public:
-  explicit LinuxPerfRingBuffer(uint32_t a_PerfFileDescriptor);
+  explicit LinuxPerfRingBuffer(int a_PerfFileDescriptor);
   ~LinuxPerfRingBuffer();
 
   LinuxPerfRingBuffer(LinuxPerfRingBuffer&&) noexcept;
@@ -30,7 +30,7 @@ class LinuxPerfRingBuffer {
   void ReadHeader(perf_event_header* a_Header);
   void SkipRecord(const perf_event_header& a_Header);
 
-  uint32_t FileDescriptor() const { return m_FileDescriptor; }
+  int FileDescriptor() const { return m_FileDescriptor; }
 
   template <typename LinuxPerfEvent>
   LinuxPerfEvent ConsumeRecord(const perf_event_header& a_Header) {
@@ -62,7 +62,7 @@ class LinuxPerfRingBuffer {
   // http://man7.org/linux/man-pages/man2/perf_event_open.2.html
   const size_t MMAP_LENGTH = (1 + RING_BUFFER_PAGE_COUNT) * PAGE_SIZE;
 
-  int32_t m_FileDescriptor = -1;
+  int m_FileDescriptor = -1;
   perf_event_mmap_page* m_Metadata = nullptr;
   char* m_Buffer = nullptr;
   uint64_t m_BufferLength = 0;

--- a/OrbitCore/LinuxPerfUtils.cpp
+++ b/OrbitCore/LinuxPerfUtils.cpp
@@ -15,7 +15,6 @@
 
 #include "LinuxUtils.h"
 #include "PrintVar.h"
-#include "ScopeTimer.h"
 
 namespace LinuxPerfUtils {
 namespace {
@@ -28,8 +27,9 @@ perf_event_attr generic_event_attr() {
   pe.sample_id_all = 1;  // also include timestamps for lost events
   pe.disabled = 1;
 
-  // We can set these even if we do not do sampling, as without the flag being
-  // set in sample_type they won't be used anyways.
+  // We can set these even if we do not do sampling, as without the
+  // PERF_SAMPLE_STACK_USER or PERF_SAMPLE_REGS_USER flags being set in
+  // perf_event_attr::sample_type they will not be used anyways.
   pe.sample_stack_user = SAMPLE_STACK_USER_SIZE;
   pe.sample_regs_user = SAMPLE_REGS_USER_ALL;
 

--- a/OrbitCore/LinuxPerfUtils.h
+++ b/OrbitCore/LinuxPerfUtils.h
@@ -19,6 +19,7 @@
 
 #include <cerrno>
 #include <cstdint>
+#include <ctime>
 
 inline int32_t perf_event_open(struct perf_event_attr* attr, pid_t pid,
                                int32_t cpu, int32_t group_fd, uint64_t flags) {
@@ -26,6 +27,13 @@ inline int32_t perf_event_open(struct perf_event_attr* attr, pid_t pid,
 }
 
 namespace LinuxPerfUtils {
+
+inline uint64_t GetClockRealtime() {
+  timespec ts{};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1'000'000'000ul + ts.tv_nsec;
+}
+
 // This must be in sync with the struct perf_sample_id defined below.
 static constexpr uint64_t SAMPLE_TYPE_BASIC_FLAGS =
     PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CPU;
@@ -107,11 +115,6 @@ int32_t task_event_open(int32_t cpu);
 
 // perf_event_open for context switches.
 int32_t context_switch_open(pid_t pid, int32_t cpu);
-
-// perf_event_open for kernel tracepoints.
-int32_t tracepoint_event_open(uint64_t a_TracepointID, pid_t a_PID,
-                              int32_t a_CPU,
-                              uint64_t additional_sample_type = 0);
 
 // perf_event_open for stack sampling.
 int32_t stack_sample_event_open(pid_t pid, uint64_t period_ns);

--- a/OrbitCore/LinuxPerfUtils.h
+++ b/OrbitCore/LinuxPerfUtils.h
@@ -28,12 +28,6 @@ inline int32_t perf_event_open(struct perf_event_attr* attr, pid_t pid,
 
 namespace LinuxPerfUtils {
 
-inline uint64_t GetClockRealtime() {
-  timespec ts{};
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return ts.tv_sec * 1'000'000'000ul + ts.tv_nsec;
-}
-
 // This must be in sync with the struct perf_sample_id defined below.
 static constexpr uint64_t SAMPLE_TYPE_BASIC_FLAGS =
     PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CPU;

--- a/OrbitCore/LinuxUprobesUnwindingVisitor.cpp
+++ b/OrbitCore/LinuxUprobesUnwindingVisitor.cpp
@@ -1,0 +1,169 @@
+#include "LinuxUprobesUnwindingVisitor.h"
+
+#include "Callstack.h"
+#include "Capture.h"
+#include "CoreApp.h"
+#include "LinuxUtils.h"
+#include "OrbitModule.h"
+#include "OrbitProcess.h"
+#include "Path.h"
+
+std::vector<unwindstack::FrameData>
+LinuxUprobesUnwindingVisitor::JoinCallstackWithPreviousUprobesCallstacks(
+    const std::vector<unwindstack::FrameData>& this_callstack,
+    const std::vector<std::vector<unwindstack::FrameData>>&
+        previous_callstacks) {
+  if (this_callstack.empty()) {
+    // This callstack is an unwinding failure.
+    return {};
+  }
+
+  if (this_callstack.back().map_name != "[uprobes]") {
+    // This callstack is already complete.
+    return this_callstack;
+  }
+
+  for (auto previous_callstack = previous_callstacks.rbegin();
+       previous_callstack != previous_callstacks.rend(); ++previous_callstack) {
+    if (previous_callstack->empty()) {
+      // A previous callstack was an unwinding failure, hence unfortunately this
+      // is a failure as well.
+      return {};
+    }
+  }
+
+  std::vector<unwindstack::FrameData> full_callstack = this_callstack;
+  full_callstack.pop_back();  // Remove [uprobes] entry.
+
+  // Append the previous callstacks, from the most recent.
+  for (auto previous_callstack = previous_callstacks.rbegin();
+       previous_callstack != previous_callstacks.rend(); ++previous_callstack) {
+    for (const auto& frame : *previous_callstack) {
+      full_callstack.push_back(frame);
+    }
+  }
+
+  return full_callstack;
+}
+
+void LinuxUprobesUnwindingVisitor::visit(LinuxStackSampleEvent* event) {
+  const std::vector<unwindstack::FrameData>& callstack = unwinder_.Unwind(
+      event->Registers(), event->StackDump(), event->StackSize());
+  const std::vector<unwindstack::FrameData>& full_callstack =
+      JoinCallstackWithPreviousUprobesCallstacks(
+          callstack, tid_uprobes_callstacks_stacks_[event->TID()]);
+  if (!full_callstack.empty()) {
+    HandleCallstack(event->TID(), event->Timestamp(), full_callstack);
+  }
+}
+
+void LinuxUprobesUnwindingVisitor::visit(LinuxUprobeEventWithStack* event) {
+  Timer timer;
+  timer.m_TID = event->TID();
+  timer.m_Start = event->Timestamp();
+  timer.m_Depth = static_cast<uint8_t>(tid_timer_stacks_[event->TID()].size());
+  timer.m_FunctionAddress = event->GetFunction()->GetVirtualAddress();
+  tid_timer_stacks_[event->TID()].push_back(timer);
+
+  std::vector<std::vector<unwindstack::FrameData>>& previous_callstacks =
+      tid_uprobes_callstacks_stacks_[event->TID()];
+  const std::vector<unwindstack::FrameData>& callstack = unwinder_.Unwind(
+      event->Registers(), event->StackDump(), event->StackSize());
+  const std::vector<unwindstack::FrameData>& full_callstack =
+      JoinCallstackWithPreviousUprobesCallstacks(callstack,
+                                                 previous_callstacks);
+
+  // TODO: Callstacks at the beginning and/or end of a dynamically-instrumented
+  //  function could alter the statistics of time-based callstack sampling.
+  //  Consider not/conditionally adding these callstacks to the trace.
+  if (!full_callstack.empty()) {
+    HandleCallstack(event->TID(), event->Timestamp(), full_callstack);
+  }
+
+  if (!callstack.empty()) {
+    std::vector<unwindstack::FrameData> uprobes_callstack{};
+    // Start from 1 to remove the instrumented function's entry.
+    for (size_t i = 1; i < callstack.size(); ++i) {
+      uprobes_callstack.push_back(callstack[i]);
+    }
+    if (uprobes_callstack.back().map_name == "[uprobes]") {
+      // Remove the [uprobes] entry from the bottom.
+      uprobes_callstack.pop_back();
+    }
+    previous_callstacks.push_back(std::move(uprobes_callstack));
+
+  } else {
+    // Put a placeholder indicating an error on the stack.
+    previous_callstacks.emplace_back();
+  }
+}
+
+void LinuxUprobesUnwindingVisitor::visit(LinuxUretprobeEventWithStack* event) {
+  std::vector<Timer>& timers = tid_timer_stacks_[event->TID()];
+  std::vector<std::vector<unwindstack::FrameData>>& previous_callstacks =
+      tid_uprobes_callstacks_stacks_[event->TID()];
+
+  assert(timers.size() == previous_callstacks.size());
+  if (!timers.empty()) {
+    Timer& timer = timers.back();
+    timer.m_End = event->Timestamp();
+    GCoreApp->ProcessTimer(
+        &timer, std::to_string(event->GetFunction()->GetVirtualAddress()));
+    timers.pop_back();
+
+    previous_callstacks.pop_back();
+  }
+
+  // Remove this if we do now want a callstack at the return of an instrumented
+  // function.
+  const std::vector<unwindstack::FrameData>& callstack = unwinder_.Unwind(
+      event->Registers(), event->StackDump(), event->StackSize());
+  const std::vector<unwindstack::FrameData>& full_callstack =
+      JoinCallstackWithPreviousUprobesCallstacks(callstack,
+                                                 previous_callstacks);
+  if (!full_callstack.empty()) {
+    HandleCallstack(event->TID(), event->Timestamp(), full_callstack);
+  }
+
+  assert(timers.size() == previous_callstacks.size());
+  if (timers.empty()) {
+    tid_timer_stacks_.erase(event->TID());
+    tid_uprobes_callstacks_stacks_.erase(event->TID());
+  }
+}
+
+void LinuxUprobesUnwindingVisitor::visit(LinuxMapsEvent* event) {
+  unwinder_.SetMaps(event->Maps());
+}
+
+void LinuxUprobesUnwindingVisitor::HandleCallstack(
+    pid_t tid, uint64_t timestamp,
+    const std::vector<unwindstack::FrameData>& frames) {
+  CallStack cs;
+  cs.m_ThreadId = tid;
+  for (const auto& frame : frames) {
+    // TODO: Avoid repeating symbol resolution by caching already seen PCs.
+    std::wstring moduleName = ToLower(Path::GetFileName(s2ws(frame.map_name)));
+    std::shared_ptr<Module> moduleFromName =
+        Capture::GTargetProcess->GetModuleFromName(ws2s(moduleName));
+
+    uint64_t address = frame.pc;
+    if (moduleFromName) {
+      uint64_t new_address = moduleFromName->ValidateAddress(address);
+      address = new_address;
+    }
+    cs.m_Data.push_back(address);
+
+    if (!frame.function_name.empty() &&
+        !Capture::GTargetProcess->HasSymbol(address)) {
+      std::stringstream ss;
+      ss << LinuxUtils::Demangle(frame.function_name.c_str()) << "+0x"
+         << std::hex << frame.function_offset;
+      GCoreApp->AddSymbol(address, frame.map_name, ss.str());
+    }
+  }
+  cs.m_Depth = cs.m_Data.size();
+
+  LinuxCallstackEvent callstack_event{"", timestamp, 1, cs};
+  GCoreApp->ProcessSamplingCallStack(callstack_event);
+}

--- a/OrbitCore/LinuxUprobesUnwindingVisitor.h
+++ b/OrbitCore/LinuxUprobesUnwindingVisitor.h
@@ -6,19 +6,50 @@
 #include "LinuxPerfEventVisitor.h"
 #include "ScopeTimer.h"
 
-// This visitor processes stack samples and uprobes/uretprobes records (as well
-// as memory maps changes, to keep necessary unwinding information up-to-date),
-// assuming they come in order.
+// LinuxUprobesUnwindingVisitor visitor processes stack samples and
+// uprobes/uretprobes records (as well as memory maps changes, to keep necessary
+// unwinding information up-to-date), assuming they come in order.
 // The reason for processing both in the same visitor is that, when entering a
 // dynamically-instrumented function, the return address saved on the stack is
 // hijacked by uretprobes. This causes unwinding of any (time-based) stack
 // sample that falls inside such a function to stop at the first of such
 // functions.
-// In order to reconstruct such broken callstacks, we keep a stack, for every
-// thread, of (broken) callstacks collected at the beginning of instrumented
-// functions. When we have a callstack broken because of uretprobes we can then
-// rebuild the missing part by joining together the parts on the stack of
-// callstacks associated with that thread.
+// In order to reconstruct such broken callstacks, UprobesCallstackManager keeps
+// a stack, for every thread, of (broken) callstacks collected at the beginning
+// of instrumented functions. When we have a callstack broken because of
+// uretprobes we can then rebuild the missing part by joining together the parts
+// on the stack of callstacks associated with that thread.
+
+class UprobesCallstackManager {
+ public:
+  UprobesCallstackManager() = default;
+
+  UprobesCallstackManager(const UprobesCallstackManager&) = delete;
+  UprobesCallstackManager& operator=(const UprobesCallstackManager&) = delete;
+
+  UprobesCallstackManager(UprobesCallstackManager&&) = default;
+  UprobesCallstackManager& operator=(UprobesCallstackManager&&) = default;
+
+  std::vector<unwindstack::FrameData> ProcessUprobesCallstack(
+      pid_t tid, const std::vector<unwindstack::FrameData>& callstack);
+  std::vector<unwindstack::FrameData> ProcessSampledCallstack(
+      pid_t tid, const std::vector<unwindstack::FrameData>& callstack);
+  std::vector<unwindstack::FrameData> ProcessUretprobesCallstack(
+      pid_t tid, const std::vector<unwindstack::FrameData>& callstack);
+
+ private:
+  // This map keeps, for every thread, the stack of callstacks collected when
+  // entering a uprobes-instrumented function.
+  std::unordered_map<pid_t, std::vector<std::vector<unwindstack::FrameData>>>
+      tid_uprobes_callstacks_stacks_{};
+
+  static std::vector<unwindstack::FrameData>
+  JoinCallstackWithPreviousUprobesCallstacks(
+      const std::vector<unwindstack::FrameData>& this_callstack,
+      const std::vector<std::vector<unwindstack::FrameData>>&
+          previous_callstacks);
+};
+
 class LinuxUprobesUnwindingVisitor : public LinuxPerfEventVisitor {
  public:
   explicit LinuxUprobesUnwindingVisitor(pid_t pid, const std::string& maps)
@@ -45,16 +76,8 @@ class LinuxUprobesUnwindingVisitor : public LinuxPerfEventVisitor {
   std::unordered_map<pid_t, std::vector<Timer>> tid_timer_stacks_{};
 
   LibunwindstackUnwinder unwinder_{};
-  // This map keeps, for every thread, the stack of callstacks collected when
-  // entering a uprobes-instrumented function.
-  std::unordered_map<pid_t, std::vector<std::vector<unwindstack::FrameData>>>
-      tid_uprobes_callstacks_stacks_{};
+  UprobesCallstackManager callstack_manager_{};
 
-  static std::vector<unwindstack::FrameData>
-  JoinCallstackWithPreviousUprobesCallstacks(
-      const std::vector<unwindstack::FrameData>& this_callstack,
-      const std::vector<std::vector<unwindstack::FrameData>>&
-          previous_callstacks);
   static void HandleCallstack(
       pid_t tid, uint64_t timestamp,
       const std::vector<unwindstack::FrameData>& frames);

--- a/OrbitCore/LinuxUprobesUnwindingVisitor.h
+++ b/OrbitCore/LinuxUprobesUnwindingVisitor.h
@@ -1,0 +1,63 @@
+#ifndef ORBIT_CORE_LINUX_UPROBES_UNWINDING_VISITOR_H_
+#define ORBIT_CORE_LINUX_UPROBES_UNWINDING_VISITOR_H_
+
+#include "LibunwindstackUnwinder.h"
+#include "LinuxPerfEvent.h"
+#include "LinuxPerfEventVisitor.h"
+#include "ScopeTimer.h"
+
+// This visitor processes stack samples and uprobes/uretprobes records (as well
+// as memory maps changes, to keep necessary unwinding information up-to-date),
+// assuming they come in order.
+// The reason for processing both in the same visitor is that, when entering a
+// dynamically-instrumented function, the return address saved on the stack is
+// hijacked by uretprobes. This causes unwinding of any (time-based) stack
+// sample that falls inside such a function to stop at the first of such
+// functions.
+// In order to reconstruct such broken callstacks, we keep a stack, for every
+// thread, of (broken) callstacks collected at the beginning of instrumented
+// functions. When we have a callstack broken because of uretprobes we can then
+// rebuild the missing part by joining together the parts on the stack of
+// callstacks associated with that thread.
+class LinuxUprobesUnwindingVisitor : public LinuxPerfEventVisitor {
+ public:
+  explicit LinuxUprobesUnwindingVisitor(pid_t pid, const std::string& maps)
+      : pid_{pid} {
+    unwinder_.SetMaps(maps);
+  }
+
+  LinuxUprobesUnwindingVisitor(const LinuxUprobesUnwindingVisitor&) = delete;
+  LinuxUprobesUnwindingVisitor& operator=(const LinuxUprobesUnwindingVisitor&) =
+      delete;
+
+  LinuxUprobesUnwindingVisitor(LinuxUprobesUnwindingVisitor&&) = default;
+  LinuxUprobesUnwindingVisitor& operator=(LinuxUprobesUnwindingVisitor&&) =
+      default;
+
+  void visit(LinuxStackSampleEvent* event) override;
+  void visit(LinuxUprobeEventWithStack* event) override;
+  void visit(LinuxUretprobeEventWithStack* event) override;
+  void visit(LinuxMapsEvent* event) override;
+
+ private:
+  pid_t pid_;
+  // This map keeps the stack of the dynamically-instrumented functions entered.
+  std::unordered_map<pid_t, std::vector<Timer>> tid_timer_stacks_{};
+
+  LibunwindstackUnwinder unwinder_{};
+  // This map keeps, for every thread, the stack of callstacks collected when
+  // entering a uprobes-instrumented function.
+  std::unordered_map<pid_t, std::vector<std::vector<unwindstack::FrameData>>>
+      tid_uprobes_callstacks_stacks_{};
+
+  static std::vector<unwindstack::FrameData>
+  JoinCallstackWithPreviousUprobesCallstacks(
+      const std::vector<unwindstack::FrameData>& this_callstack,
+      const std::vector<std::vector<unwindstack::FrameData>>&
+          previous_callstacks);
+  static void HandleCallstack(
+      pid_t tid, uint64_t timestamp,
+      const std::vector<unwindstack::FrameData>& frames);
+};
+
+#endif  // ORBIT_CORE_LINUX_UPROBES_UNWINDING_VISITOR_H_

--- a/OrbitCore/LinuxUprobesUnwindingVisitorTests.cpp
+++ b/OrbitCore/LinuxUprobesUnwindingVisitorTests.cpp
@@ -1,3 +1,292 @@
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include <utility>
+
 #include "LinuxUprobesUnwindingVisitor.h"
+
+namespace {
+unwindstack::FrameData MakeTestFrame(std::string function_name) {
+  unwindstack::FrameData frame_data{};
+  frame_data.function_name = std::move(function_name);
+  frame_data.map_name = "a.out";
+  return frame_data;
+}
+
+std::vector<unwindstack::FrameData> MakeTestCallstack(
+    const std::vector<std::string>& function_names) {
+  std::vector<unwindstack::FrameData> callstack;
+  for (auto name_it = function_names.rbegin(); name_it != function_names.rend();
+       ++name_it) {
+    callstack.push_back(MakeTestFrame(*name_it));
+  }
+  return callstack;
+}
+
+unwindstack::FrameData MakeTestUprobesFrame() {
+  unwindstack::FrameData uprobes_frame{};
+  uprobes_frame.function_name = "uprobes";
+  uprobes_frame.map_name = "[uprobes]";
+  return uprobes_frame;
+}
+
+std::vector<unwindstack::FrameData> MakeTestUprobesCallstack(
+    const std::vector<std::string>& function_names) {
+  std::vector<unwindstack::FrameData> callstack;
+  for (auto name_it = function_names.rbegin(); name_it != function_names.rend();
+       ++name_it) {
+    callstack.push_back(MakeTestFrame(*name_it));
+  }
+  callstack.push_back(MakeTestUprobesFrame());
+  return callstack;
+}
+
+std::vector<std::pair<std::string, std::string>>
+TestCallstackToStringPairVector(
+    const std::vector<unwindstack::FrameData>& callstack) {
+  std::vector<std::pair<std::string, std::string>> vector{};
+  for (const auto& frame : callstack) {
+    vector.emplace_back(frame.map_name, frame.function_name);
+  }
+  return vector;
+}
+}  // namespace
+
+TEST(UprobesCallstackManager, NoUprobes) {
+  std::vector<unwindstack::FrameData> unwound_cs, real_cs, processed_cs;
+  UprobesCallstackManager callstack_manager{};
+
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha", "beta"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha", "gamma"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+}
+
+TEST(UprobesCallstackManager, OneUprobe) {
+  std::vector<unwindstack::FrameData> unwound_cs, real_cs, processed_cs;
+  UprobesCallstackManager callstack_manager{};
+
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // Begin FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha", "FUNCTION"});
+  processed_cs = callstack_manager.ProcessUprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = MakeTestUprobesCallstack({"FUNCTION"});
+  real_cs = MakeTestCallstack({"main", "alpha", "FUNCTION"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = MakeTestUprobesCallstack({"FUNCTION", "beta"});
+  real_cs = MakeTestCallstack({"main", "alpha", "FUNCTION", "beta"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // End FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha"});
+  processed_cs = callstack_manager.ProcessUretprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+}
+
+TEST(UprobesCallstackManager, DifferentThread) {
+  std::vector<unwindstack::FrameData> unwound_cs, real_cs, processed_cs;
+  UprobesCallstackManager callstack_manager{};
+
+  // Begin FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha", "FUNCTION"});
+  processed_cs = callstack_manager.ProcessUprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // Sample from another thread.
+  unwound_cs = real_cs = MakeTestCallstack({"thread", "omega"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(111, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // End FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha"});
+  processed_cs = callstack_manager.ProcessUretprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+}
+
+TEST(UprobesCallstackManager, TwoNestedUprobesAndAnotherUprobe) {
+  std::vector<unwindstack::FrameData> unwound_cs, real_cs, processed_cs;
+  UprobesCallstackManager callstack_manager{};
+
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // Begin FOO().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha", "FOO"});
+  processed_cs = callstack_manager.ProcessUprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = MakeTestUprobesCallstack({"FOO"});
+  real_cs = MakeTestCallstack({"main", "alpha", "FOO"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // Begin BAR().
+  unwound_cs = MakeTestUprobesCallstack({"FOO", "beta", "BAR"});
+  real_cs = MakeTestCallstack({"main", "alpha", "FOO", "beta", "BAR"});
+  processed_cs = callstack_manager.ProcessUprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = MakeTestUprobesCallstack({"BAR", "gamma"});
+  real_cs = MakeTestCallstack({"main", "alpha", "FOO", "beta", "BAR", "gamma"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // End BAR().
+  unwound_cs = MakeTestUprobesCallstack({"FOO"});
+  real_cs = MakeTestCallstack({"main", "alpha", "FOO"});
+  processed_cs = callstack_manager.ProcessUretprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = MakeTestUprobesCallstack({
+      "FOO",
+      "delta",
+  });
+  real_cs = MakeTestCallstack({"main", "alpha", "FOO", "delta"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // End FOO().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha"});
+  processed_cs = callstack_manager.ProcessUretprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = real_cs = MakeTestCallstack({"main"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // Begin FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "epsilon", "FUNCTION"});
+  processed_cs = callstack_manager.ProcessUprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = MakeTestUprobesCallstack({"FUNCTION"});
+  real_cs = MakeTestCallstack({"main", "epsilon", "FUNCTION"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = MakeTestUprobesCallstack({"FUNCTION", "zeta"});
+  real_cs = MakeTestCallstack({"main", "epsilon", "FUNCTION", "zeta"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // End FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "epsilon"});
+  processed_cs = callstack_manager.ProcessUretprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = real_cs = MakeTestCallstack({"main"});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+}
+
+TEST(UprobesCallstackManager, UnwindingError) {
+  std::vector<unwindstack::FrameData> unwound_cs, real_cs, processed_cs;
+  UprobesCallstackManager callstack_manager{};
+
+  // Begin FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha", "FUNCTION"});
+  processed_cs = callstack_manager.ProcessUprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // Unwind error.
+  unwound_cs = real_cs = MakeTestCallstack({});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // End FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha"});
+  processed_cs = callstack_manager.ProcessUretprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+}
+
+TEST(UprobesCallstackManager, UnwindingErrorOnStack) {
+  std::vector<unwindstack::FrameData> unwound_cs, real_cs, processed_cs;
+  UprobesCallstackManager callstack_manager{};
+
+  // Begin FUNCTION() with unwind error.
+  unwound_cs = real_cs = MakeTestCallstack({});
+  processed_cs = callstack_manager.ProcessUprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  unwound_cs = MakeTestUprobesCallstack({"FUNCTION", "beta"});
+  real_cs = MakeTestCallstack({});
+  processed_cs = callstack_manager.ProcessSampledCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+
+  // End FUNCTION().
+  unwound_cs = real_cs = MakeTestCallstack({"main", "alpha"});
+  processed_cs = callstack_manager.ProcessUretprobesCallstack(42, unwound_cs);
+  EXPECT_THAT(
+      TestCallstackToStringPairVector(processed_cs),
+      ::testing::ElementsAreArray(TestCallstackToStringPairVector(real_cs)));
+}

--- a/OrbitCore/LinuxUprobesUnwindingVisitorTests.cpp
+++ b/OrbitCore/LinuxUprobesUnwindingVisitorTests.cpp
@@ -1,4 +1,3 @@
-//
-// Created by dpallotti on 2/3/20.
-//
+#include <gtest/gtest.h>
 
+#include "LinuxUprobesUnwindingVisitor.h"

--- a/OrbitCore/LinuxUprobesUnwindingVisitorTests.cpp
+++ b/OrbitCore/LinuxUprobesUnwindingVisitorTests.cpp
@@ -1,0 +1,4 @@
+//
+// Created by dpallotti on 2/3/20.
+//
+

--- a/OrbitCore/RingBufferTests.cpp
+++ b/OrbitCore/RingBufferTests.cpp
@@ -1,9 +1,9 @@
-#include "RingBuffer.h"
+#include <gtest/gtest.h>
 
 #include <cstdint>
 #include <utility>
 
-#include <gtest/gtest.h>
+#include "RingBuffer.h"
 
 TEST(RingBuffer, Add) {
   RingBuffer<uint64_t, 5> ring_buffer;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -307,13 +307,13 @@ void OrbitApp::ProcessCallStack(CallStack& a_CallStack) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitApp::ProcessContextSwitch(const ContextSwitch& a_CallStack) {
+void OrbitApp::ProcessContextSwitch(const ContextSwitch& a_ContextSwitch) {
   if (ConnectionManager::Get().IsService()) {
     ScopeLock lock(m_ContextSwitchMutex);
-    m_ContextSwitchBuffer.push_back(a_CallStack);
+    m_ContextSwitchBuffer.push_back(a_ContextSwitch);
   }
 
-  GTimerManager->Add(a_CallStack);
+  GTimerManager->Add(a_ContextSwitch);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -202,7 +202,7 @@ void OrbitApp::ProcessBufferedCaptureData() {
     // timers:
     {
       ScopeLock lock(m_TimerMutex);
-      if (m_TimerBuffer.size() > 0) {
+      if (!m_TimerBuffer.empty()) {
         Message Msg(Msg_RemoteTimers);
         Msg.m_Size = uint32_t(sizeof(Timer) * m_TimerBuffer.size());
         GTcpServer->Send(Msg, (void*)m_TimerBuffer.data());
@@ -213,7 +213,7 @@ void OrbitApp::ProcessBufferedCaptureData() {
     // sampling callstacks
     {
       ScopeLock lock(m_SamplingCallstackMutex);
-      if (m_SamplingCallstackBuffer.size() > 0) {
+      if (!m_SamplingCallstackBuffer.empty()) {
         std::string messageData =
             SerializeObjectBinary(m_SamplingCallstackBuffer);
         GTcpServer->Send(Msg_SamplingCallstacks, messageData.c_str(),
@@ -225,7 +225,7 @@ void OrbitApp::ProcessBufferedCaptureData() {
     // hashed sampling callstacks
     {
       ScopeLock lock(m_HashedSamplingCallstackMutex);
-      if (m_HashedSamplingCallstackBuffer.size() > 0) {
+      if (!m_HashedSamplingCallstackBuffer.empty()) {
         std::string messageData =
             SerializeObjectBinary(m_HashedSamplingCallstackBuffer);
         GTcpServer->Send(Msg_SamplingHashedCallstacks, messageData.c_str(),
@@ -237,7 +237,7 @@ void OrbitApp::ProcessBufferedCaptureData() {
     // context switches
     {
       ScopeLock lock(m_ContextSwitchMutex);
-      if (m_ContextSwitchBuffer.size() > 0) {
+      if (!m_ContextSwitchBuffer.empty()) {
         Message Msg(Msg_RemoteContextSwitches);
         Msg.m_Size =
             uint32_t(sizeof(ContextSwitch) * m_ContextSwitchBuffer.size());

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -77,7 +77,7 @@ class OrbitApp : public CoreApp {
   virtual void ProcessSamplingCallStack(LinuxCallstackEvent& a_CallStack);
   virtual void ProcessHashedSamplingCallStack(CallstackEvent& a_CallStack);
   virtual void ProcessCallStack(CallStack& a_CallStack);
-  virtual void ProcessContextSwitch(const ContextSwitch& a_CallStack);
+  virtual void ProcessContextSwitch(const ContextSwitch& a_ContextSwitch);
   virtual void AddSymbol(uint64_t a_Address, const std::string& a_Module,
                          const std::string& a_Name);
   void ProcessBufferedCaptureData();

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -276,7 +276,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
       std::map<long long, ContextSwitch>& csMap =
           m_CoreUtilizationMap[a_CS.m_ProcessorIndex];
 
-      if (csMap.rbegin() != csMap.rend()) {
+      if (!csMap.empty()) {
         ContextSwitch& lastCS = csMap.rbegin()->second;
         if (lastCS.m_Type == ContextSwitch::In) {
           Timer timer;
@@ -297,7 +297,7 @@ void TimeGraph::AddContextSwitch(const ContextSwitch& a_CS) {
       std::map<long long, ContextSwitch>& csMap =
           m_ContextSwitchesMap[a_CS.m_ThreadId];
 
-      if (csMap.rbegin() != csMap.rend()) {
+      if (!csMap.empty()) {
         ContextSwitch& lastCS = csMap.rbegin()->second;
         if (lastCS.m_Type == ContextSwitch::In) {
           Timer timer;


### PR DESCRIPTION
Uretprobes causes unwinding of stack samples falling inside uprobes-instrumented
functions to stop at the first of such functions to be encountered. We solve
this by processing u(ret)probes and stack samples in order and keeping a stack
of collected at the beginning of uprobes-instrumented functions to rebuild such
broken callstacks. See LinuxUprobesUnwindingVisitor.h for more details.