### PR TITLE
[Regression Fix] Fix xxHash cmake configuration

### DIFF
--- a/cmake/FindxxHash.cmake
+++ b/cmake/FindxxHash.cmake
@@ -1,6 +1,6 @@
 set(DIR external/xxHash-r42)
 
-add_library(xxHash OBJECT ${DIR}/xxhash.c ${DIR}/xxhsum.c)
+add_library(xxHash OBJECT ${DIR}/xxhash.c)
 target_include_directories(xxHash SYSTEM PUBLIC ${DIR})
 
 add_library(xxHash::xxHash ALIAS xxHash)


### PR DESCRIPTION
I accidentally added xxhsum.c form xxHash to the xxHash cmake target.

xxhsum.c is a program entry point containing a main method, which lead
to a ODR violation with OrbitCoreTests. This PR removes xxhsum.c from the
xxHash cmake target.