### PR TITLE
Bring std::string Format back to fix windows build

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -206,8 +206,12 @@ target_compile_features(OrbitCore PUBLIC cxx_std_11)
 add_executable(OrbitCoreTests)
 
 target_sources(OrbitCoreTests
-  PRIVATE LinuxUprobesUnwindingVisitorTests.cpp
-          RingBufferTests.cpp)
+  PRIVATE RingBufferTests.cpp)
+
+if(NOT WIN32)
+  target_sources(OrbitCoreTests
+    PRIVATE LinuxUprobesUnwindingVisitorTests.cpp)
+endif()
 
 target_link_libraries(
   OrbitCoreTests PRIVATE OrbitCore GTest::GTest GTest::Main)

--- a/OrbitCore/Utils.h
+++ b/OrbitCore/Utils.h
@@ -95,6 +95,15 @@ inline void Fill(T& a_Array, U& a_Value) {
 
 //-----------------------------------------------------------------------------
 template <typename... Args>
+std::string Format(const char* format, Args... args) {
+  const size_t size = 4096;
+  char buf[size];
+  snprintf(buf, size, format, args...);
+  return std::string(buf);
+}
+
+//-----------------------------------------------------------------------------
+template <typename... Args>
 std::wstring Format(const wchar_t* format, Args... args) {
   const size_t size = 4096;
   wchar_t buf[size];

--- a/OrbitGl/Disassembler.cpp
+++ b/OrbitGl/Disassembler.cpp
@@ -12,8 +12,8 @@
     m_String += s2ws(str); \
   }
 
-#define LOGF(format, args...) { \
-    std::string log = absl::StrFormat(format, args); \
+#define LOGF(...) { \
+    std::string log = absl::StrFormat(__VA_ARGS__); \
     m_String += s2ws(log); \
   }
 


### PR DESCRIPTION
This fixes windows build regression introduced by
97bbe50e2127f329ed57a922a4e6643105b10c62