### PR TITLE
Moving core components from wstring->string

### DIFF
--- a/OrbitCore/Callstack.cpp
+++ b/OrbitCore/Callstack.cpp
@@ -10,6 +10,7 @@
 #include "OrbitType.h"
 #include "PrintVar.h"
 #include "Serialization.h"
+#include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
 CallStack::CallStack(CallStackPOD a_CS) : CallStack() {
@@ -33,8 +34,8 @@ void CallStack::Print() {
 }
 
 //-----------------------------------------------------------------------------
-std::wstring CallStack::GetString() {
-  std::wstring callstackString;
+std::string CallStack::GetString() {
+  std::string callstackString;
 
   ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
   for (uint32_t i = 0; i < m_Depth; ++i) {
@@ -43,9 +44,9 @@ std::wstring CallStack::GetString() {
         Capture::GTargetProcess->GetFunctionFromAddress(addr, false);
 
     if (func) {
-      callstackString += s2ws(func->PrettyName()) + L"\n";
+      callstackString += func->PrettyName() + "\n";
     } else {
-      callstackString += Format(L"%I64x\n", addr);
+      callstackString += absl::StrFormat("%" PRIx64 "\n", addr);
     }
   }
 

--- a/OrbitCore/Callstack.h
+++ b/OrbitCore/Callstack.h
@@ -39,7 +39,7 @@ struct CallStack {
     return m_Hash;
   }
   void Print();
-  std::wstring GetString();
+  std::string GetString();
   void Clear() {
     m_Data.clear();
     m_Hash = m_Depth = m_ThreadId = 0;

--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -28,6 +28,7 @@
 #include "TcpServer.h"
 #include "TestRemoteMessages.h"
 #include "TimerManager.h"
+#include "absl/strings/str_format.h"
 
 #ifdef _WIN32
 #include "EventTracer.h"
@@ -163,7 +164,7 @@ bool Capture::Connect() {
 
 //-----------------------------------------------------------------------------
 bool Capture::StartCapture() {
-  SCOPE_TIMER_LOG(L"Capture::StartCapture");
+  SCOPE_TIMER_LOG("Capture::StartCapture");
 
   if (GTargetProcess->GetName().size() == 0) return false;
 
@@ -407,7 +408,7 @@ void Capture::StartSampling() {
 #ifdef WIN32
   if (!GIsSampling && Capture::IsTrackingEvents() &&
       GTargetProcess->GetName().size()) {
-    SCOPE_TIMER_LOG(L"Capture::StartSampling");
+    SCOPE_TIMER_LOG("Capture::StartSampling");
 
     GCaptureTimer.Start();
     GCaptureTimePoint = std::chrono::system_clock::now();
@@ -482,7 +483,7 @@ void Capture::DisplayStats() {
 //-----------------------------------------------------------------------------
 void Capture::OpenCapture(const std::wstring& a_CaptureName) {
   LocalScopeTimer Timer(&GOpenCaptureTime);
-  SCOPE_TIMER_LOG(L"OpenCapture");
+  SCOPE_TIMER_LOG("OpenCapture");
 
   // TODO!
 }
@@ -542,13 +543,14 @@ void Capture::SaveSession(const std::wstring& a_FileName) {
     }
   }
 
-  std::wstring saveFileName = a_FileName;
+  std::string saveFileName = ws2s(a_FileName);
   if (!EndsWith(a_FileName, L".opr")) {
-    saveFileName += L".opr";
+    saveFileName += ".opr";
   }
 
-  SCOPE_TIMER_LOG(Format(L"Saving Orbit session in %s", saveFileName.c_str()));
-  std::ofstream file(ws2s(saveFileName), std::ios::binary);
+  SCOPE_TIMER_LOG(absl::StrFormat("Saving Orbit session in %s",
+                                  saveFileName.c_str()));
+  std::ofstream file(saveFileName, std::ios::binary);
   cereal::BinaryOutputArchive archive(file);
   archive(cereal::make_nvp("Session", session));
 }

--- a/OrbitCore/MemoryTracker.cpp
+++ b/OrbitCore/MemoryTracker.cpp
@@ -8,6 +8,7 @@
 #include "Capture.h"
 #include "Log.h"
 #include "OrbitProcess.h"
+#include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
 MemoryTracker::MemoryTracker()
@@ -57,7 +58,7 @@ void MemoryTracker::DumpReport() {
   }
 
   if (m_NumAllocatedBytes) {
-    ORBIT_VIZ(Format(L"NumLiveBytes: %llu\n", NumLiveBytes));
+    ORBIT_VIZ(absl::StrFormat("NumLiveBytes: %llu\n", NumLiveBytes));
   }
 
   for (auto rit = bytesToCallstack.rbegin(); rit != bytesToCallstack.rend();
@@ -67,13 +68,13 @@ void MemoryTracker::DumpReport() {
 
     DWORD64 numBytes = rit->first;
     DWORD64 cid = id;
-    std::wstring msg =
-        Format(L"Callstack[%llu] allocated %llu bytes\n", cid, numBytes);
+    std::string msg = absl::StrFormat("Callstack[%llu] allocated %llu bytes\n",
+                                      cid, numBytes);
     ORBIT_VIZ(msg);
     if (callstack) {
       ORBIT_VIZ(callstack->GetString());
     }
-    ORBIT_VIZ(L"\n\n");
+    ORBIT_VIZ("\n\n");
   }
 }
 

--- a/OrbitCore/OrbitModule.cpp
+++ b/OrbitCore/OrbitModule.cpp
@@ -139,7 +139,7 @@ bool Pdb::LoadPdb(const wchar_t* a_PdbName) {
   m_Name = Path::GetFileName(m_FileName);
 
   {
-    SCOPE_TIMER_LOG(L"nm");
+    SCOPE_TIMER_LOG("nm");
     // nm
     // TODO: If we need linenumber information at some point, we need to find an
     // alternative, as "nm -l" is super slow.
@@ -166,7 +166,7 @@ bool Pdb::LoadPdb(const wchar_t* a_PdbName) {
   ProcessData();
 
   {
-    SCOPE_TIMER_LOG(L"objdump -tT");
+    SCOPE_TIMER_LOG("objdump -tT");
     // find functions that can receive uprobes
     std::string objdumpCommand =
         std::string("objdump -tT ") + ws2s(m_FileName) +
@@ -199,7 +199,7 @@ void Pdb::LoadPdbAsync(const wchar_t* a_PdbName,
 
 //-----------------------------------------------------------------------------
 void Pdb::ProcessData() {
-  SCOPE_TIMER_LOG(L"ProcessData");
+  SCOPE_TIMER_LOG("ProcessData");
   ScopeLock lock(Capture::GTargetProcess->GetDataMutex());
 
   auto& functions = Capture::GTargetProcess->GetFunctions();
@@ -214,7 +214,7 @@ void Pdb::ProcessData() {
   }
 
   if (GParams.m_FindFileAndLineInfo) {
-    SCOPE_TIMER_LOG(L"Find File and Line info");
+    SCOPE_TIMER_LOG("Find File and Line info");
     for (Function& func : m_Functions) {
       func.FindFile();
     }
@@ -243,7 +243,7 @@ void Pdb::ProcessData() {
 void Pdb::PopulateFunctionMap() {
   m_IsPopulatingFunctionMap = true;
 
-  SCOPE_TIMER_LOG(L"Pdb::PopulateFunctionMap");
+  SCOPE_TIMER_LOG("Pdb::PopulateFunctionMap");
 
   uint64_t baseAddress = (uint64_t)GetHModule();
   bool rvaAddresses = false;
@@ -271,19 +271,19 @@ void Pdb::PopulateStringFunctionMap() {
   m_IsPopulatingFunctionStringMap = true;
 
   {
-    // SCOPE_TIMER_LOG( L"Reserving map" );
+    // SCOPE_TIMER_LOG("Reserving map");
     m_StringFunctionMap.reserve(unsigned(1.5f * (float)m_Functions.size()));
   }
 
   {
-    // SCOPE_TIMER_LOG( L"Hash" );
+    // SCOPE_TIMER_LOG("Hash");
     for (Function& Function : m_Functions) {
       Function.Hash();
     }
   }
 
   {
-    // SCOPE_TIMER_LOG( L"Map inserts" );
+    // SCOPE_TIMER_LOG("Map inserts");
 
     for (Function& Function : m_Functions) {
       m_StringFunctionMap[Function.m_NameHash] = &Function;

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -97,7 +97,7 @@ void Process::SetID(DWORD a_ID) {
 
 //-----------------------------------------------------------------------------
 void Process::ListModules() {
-  SCOPE_TIMER_LOG(L"ListModules");
+  SCOPE_TIMER_LOG("ListModules");
 
   ClearTransients();
 
@@ -497,7 +497,7 @@ DWORD64 Process::GetRaiseExceptionAddress() {
 //-----------------------------------------------------------------------------
 void Process::FindCoreFunctions() {
 #if 0
-    SCOPE_TIMER_LOG(L"FindCoreFunctions");
+    SCOPE_TIMER_LOG("FindCoreFunctions");
 
     const auto prio = oqpi::task_priority::normal;
 

--- a/OrbitCore/Params.cpp
+++ b/OrbitCore/Params.cpp
@@ -11,6 +11,7 @@
 #include "CoreApp.h"
 #include "ScopeTimer.h"
 #include "Serialization.h"
+#include "absl/strings/str_format.h"
 
 Params GParams;
 
@@ -69,7 +70,8 @@ ORBIT_SERIALIZE(Params, 16) {
 void Params::Save() {
   GCoreApp->SendToUiNow(L"UpdateProcessParams");
   std::wstring fileName = Path::GetParamsFileName();
-  SCOPE_TIMER_LOG(Format(L"Saving params in %s", fileName.c_str()));
+  SCOPE_TIMER_LOG(absl::StrFormat("Saving params in %s",
+                                  ws2s(fileName).c_str()));
   std::ofstream file(ws2s(fileName));
   cereal::XMLOutputArchive archive(file);
   archive(cereal::make_nvp("Params", *this));

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -9,7 +9,7 @@
 
 #define SCOPE_TIMER_LOG(msg) LocalScopeTimer UNIQUE_ID(msg)
 #define SCOPE_TIMER_FUNC SCOPE_TIMER_LOG(__FUNCTION__)
-extern thread_local int CurrentDepth;
+extern thread_local size_t CurrentDepth;
 
 //-----------------------------------------------------------------------------
 #pragma pack(push, 1)
@@ -109,15 +109,14 @@ class ScopeTimer {
 class LocalScopeTimer {
  public:
   LocalScopeTimer();
-  LocalScopeTimer(const std::wstring& a_Message);
-  LocalScopeTimer(const char* a_Message);
-  LocalScopeTimer(double* a_Millis);
+  LocalScopeTimer(const std::string& message);
+  LocalScopeTimer(double* millis);
   ~LocalScopeTimer();
 
  protected:
-  Timer m_Timer;
-  double* m_Millis;
-  std::wstring m_Msg;
+  Timer timer_;
+  double* millis_;
+  std::string message_;
 };
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/Systrace.cpp
+++ b/OrbitCore/Systrace.cpp
@@ -109,7 +109,7 @@ void Systrace::UpdateMinMax(const Timer& a_Timer) {
 
 //-----------------------------------------------------------------------------
 Systrace::Systrace(const char* a_FilePath, uint64_t a_TimeOffsetNs) {
-  SCOPE_TIMER_LOG(L"Systrace Parsing");
+  SCOPE_TIMER_LOG("Systrace Parsing");
   m_Name = a_FilePath;
   std::ifstream infile(a_FilePath);
   std::string line;
@@ -153,14 +153,14 @@ Systrace::Systrace(const char* a_FilePath, uint64_t a_TimeOffsetNs) {
   }
 
   {
-    SCOPE_TIMER_LOG(L"Function Map");
+    SCOPE_TIMER_LOG("Function Map");
     for (auto& function : m_Functions) {
       m_FunctionMap[function.m_Address] = &function;
     }
   }
 
   {
-    SCOPE_TIMER_LOG(L"Update Timers");
+    SCOPE_TIMER_LOG("Update Timers");
     for (auto& timer : m_Timers) {
       m_FunctionMap[timer.m_FunctionAddress]->m_Stats->Update(timer);
     }

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -17,6 +17,7 @@
 #include "Serialization.h"
 #include "TextBox.h"
 #include "TimeGraph.h"
+#include "absl/strings/str_format.h"
 
 //-----------------------------------------------------------------------------
 CaptureSerializer::CaptureSerializer() {
@@ -40,7 +41,8 @@ void CaptureSerializer::Save(const std::wstring a_FileName) {
   m_CaptureName = ws2s(a_FileName);
   std::ofstream myfile(m_CaptureName, std::ios::binary);
   if (!myfile.fail()) {
-    SCOPE_TIMER_LOG(Format(L"Saving capture in %s", a_FileName.c_str()));
+    SCOPE_TIMER_LOG(absl::StrFormat("Saving capture in %s",
+                                    ws2s(a_FileName).c_str()));
     cereal::BinaryOutputArchive archive(myfile);
     Save(archive);
     myfile.close();
@@ -114,7 +116,8 @@ void CaptureSerializer::Save(T& a_Archive) {
 
 //-----------------------------------------------------------------------------
 void CaptureSerializer::Load(const std::wstring a_FileName) {
-  SCOPE_TIMER_LOG(Format(L"Loading capture %s", a_FileName.c_str()));
+  SCOPE_TIMER_LOG(absl::StrFormat("Loading capture %s",
+                                  ws2s(a_FileName).c_str()));
 
 #ifdef _WIN32
   // Binary


### PR DESCRIPTION
This will reduce number of times we need to convert between wide and utf8 strings in our core coponent. The goal is to use wstrings only when invoking windows API that requires them and use regular strings internally.