### PR TITLE
Keep vm alive after build failure for up to two hours.

### DIFF
--- a/kokoro/gcp_ubuntu/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu/kokoro_build.sh
@@ -18,3 +18,6 @@ set -e
 # in the job configuration.
 cd ${KOKORO_ARTIFACTS_DIR}/github/orbitprofiler
 ./bootstrap-orbit.sh
+external_ip=$(curl -s -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+echo "INSTANCE_EXTERNAL_IP=${external_ip}"
+sleep 7200;


### PR DESCRIPTION
Also print the ip into the log. This enables us to ssh into the thing and debug the failure.