### PR TITLE
Don't use gold linker. 

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -28,6 +28,8 @@ fi
 # Build vcpkg
 cd external/vcpkg
 
+patch -p1 -i ../../contrib/patches/vcpkg-qt5-disable-glib.diff
+
 if [ -f "vcpkg" ]; then
   echo "Orbit: found vcpkg"
 else

--- a/contrib/patches/vcpkg-qt5-disable-glib.diff
+++ b/contrib/patches/vcpkg-qt5-disable-glib.diff
@@ -1,8 +1,16 @@
 diff --git a/ports/qt5-base/portfile.cmake b/ports/qt5-base/portfile.cmake
-index 443d462e1..b00d83b0f 100644
+index 443d462e1..cc6403d19 100644
 --- a/ports/qt5-base/portfile.cmake
 +++ b/ports/qt5-base/portfile.cmake
-@@ -82,6 +82,7 @@ list(APPEND CORE_OPTIONS
+@@ -68,6 +68,7 @@ set(CORE_OPTIONS
+     # ENV ANGLE_DIR to external angle source dir. (Will always be compiled with Qt)
+     #-optimized-tools
+     #-force-debug-info
++    -no-use-gold-linker
+     -verbose
+ )
+ 
+@@ -82,6 +83,7 @@ list(APPEND CORE_OPTIONS
      -system-sqlite
      -system-harfbuzz
      -icu


### PR DESCRIPTION
Ubuntu CI comes with the 2.30 version and there seems to be a problem when linking qt5-base. Context: https://bugreports.qt.io/browse/QTBUG-66571