### PR TITLE
Build configuration for kokoro windows build.

### DIFF
--- a/kokoro/gcp_windows/continuous.cfg
+++ b/kokoro/gcp_windows/continuous.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "orbitprofiler/kokoro/gcp_windows/kokoro_build.bat"

--- a/kokoro/gcp_windows/kokoro_build.bat
+++ b/kokoro/gcp_windows/kokoro_build.bat
@@ -1,0 +1,7 @@
+:: Code under repo is checked out to %KOKORO_ARTIFACTS_DIR%\github.
+:: The final directory name in this path is determined by the scm name specified
+:: in the job configuration
+cd %KOKORO_ARTIFACTS_DIR%\github\orbitprofiler
+
+call bootstrap-orbit.bat
+exit %ERRORLEVEL%


### PR DESCRIPTION
As with the linux version - we just call the bootstrap script.