### PR TITLE
OrbitType: wstring->string migration

### DIFF
--- a/OrbitCore/DiaParser.cpp
+++ b/OrbitCore/DiaParser.cpp
@@ -547,30 +547,47 @@ void DiaParser::PrintGlobalSymbol(IDiaSymbol* pSymbol) {
   }
 }
 
-std::wstring DiaParser::GetBasicType(DWORD a_BaseType) {
-  static std::unordered_map<DWORD, std::wstring> BasicTypeMap;
-  if (BasicTypeMap.size() == 0) {
-    BasicTypeMap[btNoType] = L"btNoType  ";
-    BasicTypeMap[btVoid] = L"void";
-    BasicTypeMap[btChar] = L"char";
-    BasicTypeMap[btWChar] = L"wchar_t";
-    BasicTypeMap[btInt] = L"int";
-    BasicTypeMap[btUInt] = L"unsigned __int32";
-    BasicTypeMap[btFloat] = L"float";
-    BasicTypeMap[btBCD] = L"btBCD";
-    BasicTypeMap[btBool] = L"bool";
-    BasicTypeMap[btLong] = L"long";
-    BasicTypeMap[btULong] = L"unsigned long";
-    BasicTypeMap[btCurrency] = L"btCurrency";
-    BasicTypeMap[btDate] = L"btDate";
-    BasicTypeMap[btVariant] = L"btVariant";
-    BasicTypeMap[btComplex] = L"btComplex";
-    BasicTypeMap[btBit] = L"btBit";
-    BasicTypeMap[btBSTR] = L"btBSTR";
-    BasicTypeMap[btHresult] = L"btHresult";
+std::string DiaParser::GetBasicType(uint32_t base_type) {
+  switch(base_type) {
+    case btNoType:
+      return "btNoType  ";
+    case btVoid:
+      return "void";
+    case btChar:
+      return "char";
+    case btWChar:
+      return "wchar_t";
+    case btInt:
+      return "int";
+    case btUInt:
+      return "unsigned __int32";
+    case btFloat:
+      return "float";
+    case btBCD:
+      return "btBCD";
+    case btBool:
+      return "bool";
+    case btLong:
+      return "long";
+    case btULong:
+      return "unsigned long";
+    case btCurrency:
+      return "btCurrency";
+    case btDate:
+      return "btDate";
+    case btVariant:
+      return "btVariant";
+    case btComplex:
+      return "btComplex";
+    case btBit:
+      return "btBit";
+    case btBSTR:
+      return "btBSTR";
+    case btHresult:
+      return "btHresult";
   }
 
-  return BasicTypeMap[a_BaseType];
+  return "unknown";
 }
 
 void DiaParser::OrbitAddGlobalSymbol(IDiaSymbol* pSymbol) {
@@ -620,17 +637,17 @@ void DiaParser::OrbitAddGlobalSymbol(IDiaSymbol* pSymbol) {
     if (pSymbol->get_name(&bstrName) == S_OK) {
       if (pSymbol->get_undecoratedName(&bstrUndname) == S_OK) {
         // LOGF(L"%s(%s)\n", bstrName, bstrUndname);
-        Var.m_Name = bstrUndname;
+        Var.m_Name = ws2s(bstrUndname);
         SysFreeString(bstrUndname);
       } else {
         // LOGF(L"%s\n", bstrName);
-        Var.m_Name = bstrName;
+        Var.m_Name = ws2s(bstrName);
       }
 
       SysFreeString(bstrName);
     }
 
-    if (Contains(Var.m_Name, L"GOutput")) {
+    if (Contains(Var.m_Name, "GOutput")) {
       static volatile bool found = false;
       found = true;
     }
@@ -642,7 +659,7 @@ void DiaParser::OrbitAddGlobalSymbol(IDiaSymbol* pSymbol) {
     if (pSymbol->get_type(&globalType.m_Symbol) == S_OK) {
       BSTR bstrTypeName;
       if (globalType.m_Symbol->get_name(&bstrTypeName) == S_OK) {
-        Var.SetType(bstrTypeName);
+        Var.SetType(ws2s(bstrTypeName));
       }
 
       DWORD baseType;
@@ -668,7 +685,7 @@ void DiaParser::OrbitAddGlobalSymbol(IDiaSymbol* pSymbol) {
 
     BSTR bstrFile;
     if (pSymbol->get_sourceFileName(&bstrFile) == S_OK) {
-      Var.m_File = bstrFile;
+      Var.m_File = ws2s(bstrFile);
     }
 
     // Var.SetType( ws2s(szTypeName) );
@@ -1927,11 +1944,11 @@ void DiaParser::GetData(IDiaSymbol* pSymbol, Type* a_OrbitType) {
       LONG lOffset;
       if (pSymbol->get_offset(&lOffset) == S_OK) {
         Variable member;
-        member.m_Name = GetName(pSymbol);
+        member.m_Name = ws2s(GetName(pSymbol));
         member.m_Size = (ULONG)GetSize(pSymbol);
         member.m_TypeIndex = GetTypeID(pSymbol);
-        member.m_Type = GetSymbolType(pSymbol);
-        member.m_PrettyTypeName = GetData(pSymbol);
+        member.m_Type = ws2s(GetSymbolType(pSymbol));
+        member.m_PrettyTypeName = ws2s(GetData(pSymbol));
         member.m_Pdb = a_OrbitType->m_Pdb;
         a_OrbitType->m_DataMembers[lOffset] = member;
         LOGF(L"this+0x%X", lOffset);

--- a/OrbitCore/DiaParser.h
+++ b/OrbitCore/DiaParser.h
@@ -23,7 +23,7 @@ struct DiaParser {
   static std::wstring GetSymbolType(IDiaSymbol*);
   static std::wstring GetName(IDiaSymbol*);
 
-  std::wstring GetBasicType(DWORD a_BaseType);
+  std::string GetBasicType(uint32_t a_BaseType);
   ULONGLONG GetSize(IDiaSymbol*);
   DWORD GetSymbolID(IDiaSymbol*);
   DWORD GetTypeID(IDiaSymbol*);

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -85,7 +85,7 @@ void Function::PreHook() {
   // Unreal
   if (Capture::GUnrealSupported) {
     Type* parent = GetParentType();
-    if (parent && parent->IsA(L"UObject")) {
+    if (parent && parent->IsA("UObject")) {
       m_OrbitType = Function::UNREAL_ACTOR;
     }
   }

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -322,7 +322,7 @@ void Process::ClearWatchedVariables() { m_WatchedVariables.clear(); }
 
 //-----------------------------------------------------------------------------
 void Process::AddType(Type& a_Type) {
-  bool isPtr = a_Type.m_Name.find(L"Pointer to") != std::string::npos;
+  bool isPtr = a_Type.m_Name.find("Pointer to") != std::string::npos;
   if (!isPtr) {
     unsigned long long typeHash = a_Type.Hash();
     auto it = m_UniqueTypeHash.insert(typeHash);

--- a/OrbitCore/OrbitType.cpp
+++ b/OrbitCore/OrbitType.cpp
@@ -193,7 +193,7 @@ int Type::GetOffset(const std::string& a_Member) {
 
   for (auto& pair : m_DataMembersFull) {
     Variable& var = pair.second;
-    if (ws2s(var.m_Name) == a_Member) {
+    if (var.m_Name == a_Member) {
       return pair.first;
     }
   }
@@ -206,7 +206,7 @@ Variable* Type::FindImmediateChild(const std::string& a_Name) {
 
   for (auto& pair : m_DataMembers) {
     Variable& var = pair.second;
-    if (ws2s(var.m_Name) == a_Name) {
+    if (var.m_Name == a_Name) {
       Type* type = var.GetType();
       type->LoadDiaInfo();
       return &var;
@@ -231,7 +231,7 @@ void Type::OutputPadding() const {
     idealNextOffset = offset + memberType.m_Length;
     if (memberType.m_Length > 0 && nextOffset > idealNextOffset) {
       Variable paddingMember;
-      paddingMember.m_Name = L"padding";
+      paddingMember.m_Name = "padding";
       paddingMember.m_TypeIndex = 0xFFFFFFFF;
       paddingMember.m_Size = ULONG(nextOffset - idealNextOffset);
       m_DataMembers[(ULONG)idealNextOffset] = paddingMember;
@@ -308,7 +308,7 @@ std::shared_ptr<Variable> Type::GenerateVariable(DWORD64 a_Address,
   var->m_Pdb = this->m_Pdb;
   var->m_Address = a_Address;
   var->m_TypeIndex = m_Id;
-  var->m_Name = s2ws(a_Name != nullptr ? *a_Name : this->m_Name);
+  var->m_Name = a_Name != nullptr ? *a_Name : this->m_Name;
   var->m_Size = (ULONG)this->m_Length;
 
   // Parents
@@ -334,7 +334,7 @@ std::shared_ptr<Variable> Type::GenerateVariable(DWORD64 a_Address,
     if (!type) continue;
 
     if (type && type->HasMembers()) {
-      std::string name = ws2s(member.m_Name);
+      std::string name = member.m_Name;
       var->AddChild(
           type->GenerateVariable(a_Address + memberOffset, &name));
     } else {

--- a/OrbitCore/OrbitType.h
+++ b/OrbitCore/OrbitType.h
@@ -16,16 +16,14 @@
 #include "Variable.h"
 #include "cvconst.h"
 
-//-----------------------------------------------------------------------------
 struct Parent {
   Parent() : m_TypeId(0), m_BaseOffset(0) {}
   Parent(ULONG Id, LONG Offset) : m_TypeId(Id), m_BaseOffset(Offset) {}
   ULONG m_TypeId;
   LONG m_BaseOffset;
-  std::wstring m_Name;
+  std::string m_Name;
 };
 
-//-----------------------------------------------------------------------------
 class Type {
  public:
   Type() {}
@@ -51,8 +49,8 @@ class Type {
   void AddParent(IDiaSymbol* a_Parent);
   const std::map<ULONG, Variable>& GetFullVariableMap() const;
   Pdb* GetPdb() const { return m_Pdb; }
-  const std::wstring& GetName() const { return m_Name; }
-  const std::wstring& GetNameLower() {
+  const std::string& GetName() const { return m_Name; }
+  const std::string& GetNameLower() {
     if (m_NameLower.size() == 0) {
       m_NameLower = ToLower(m_Name);
     }
@@ -63,14 +61,14 @@ class Type {
   std::shared_ptr<OrbitDiaSymbol> GetDiaSymbol();
 #endif
 
-  bool IsA(const std::wstring& a_TypeName);
-  int GetOffset(const std::wstring& a_Member);
+  bool IsA(const std::string& a_TypeName);
+  int GetOffset(const std::string& a_Member);
   bool HasMembers() const { return m_DataMembers.size() > 0; }
-  Variable* FindImmediateChild(const std::wstring& a_Name);
+  Variable* FindImmediateChild(const std::string& a_Name);
 
   std::shared_ptr<Variable> GetTemplateVariable();
   std::shared_ptr<Variable> GenerateVariable(
-      DWORD64 a_Address, const std::wstring* a_Name = nullptr);
+      DWORD64 a_Address, const std::string* a_Name = nullptr);
 
  protected:
   void GenerateDataLayout() const;
@@ -86,8 +84,8 @@ class Type {
   ULONG m_Id = 0;
   ULONG m_UnmodifiedId = 0;
   ULONG m_PointedTypeId = 0;
-  std::wstring m_Name;
-  std::wstring m_NameLower;
+  std::string m_Name;
+  std::string m_NameLower;
   uint64_t m_Length = 0;
   int m_NumVariables = 0;
   int m_NumFunctions = 0;

--- a/OrbitCore/OrbitUnreal.cpp
+++ b/OrbitCore/OrbitUnreal.cpp
@@ -10,9 +10,9 @@ OrbitUnreal GOrbitUnreal;
 
 //-----------------------------------------------------------------------------
 void OrbitUnreal::OnTypeAdded(Type* a_Type) {
-  if (a_Type->m_Name == L"FNameEntry") {
+  if (a_Type->m_Name == "FNameEntry") {
     m_FnameEntryType = a_Type;
-  } else if (a_Type->m_Name == L"UObject") {
+  } else if (a_Type->m_Name == "UObject") {
     m_UObjectType = a_Type;
   }
 }
@@ -39,11 +39,11 @@ bool OrbitUnreal::GenerateUnrealInfo() {
   OrbitUnrealInfo info;
   info.m_GetDisplayNameEntryAddress =
       GOrbitUnreal.m_GetDisplayNameEntryFunc->GetVirtualAddress();
-  info.m_EntryIndexOffset = m_FnameEntryType->GetOffset(L"Index");
-  info.m_UobjectNameOffset = m_UObjectType->GetOffset(L"Name");
-  info.m_EntryNameOffset = m_FnameEntryType->GetOffset(L"AnsiName");
+  info.m_EntryIndexOffset = m_FnameEntryType->GetOffset("Index");
+  info.m_UobjectNameOffset = m_UObjectType->GetOffset("Name");
+  info.m_EntryNameOffset = m_FnameEntryType->GetOffset("AnsiName");
   if (info.m_EntryNameOffset == -1) {
-    info.m_EntryNameOffset = m_FnameEntryType->GetOffset(L"WideName");
+    info.m_EntryNameOffset = m_FnameEntryType->GetOffset("WideName");
   }
 
   if (info.m_EntryNameOffset == -1 || info.m_EntryIndexOffset == -1 ||

--- a/OrbitCore/Variable.cpp
+++ b/OrbitCore/Variable.cpp
@@ -239,17 +239,18 @@ Type* Variable::GetType() {
 //-----------------------------------------------------------------------------
 std::wstring Variable::GetTypeName() const {
   const Type* type = GetType();
-  std::wstring typeName = type ? type->GetName() : L"";
-  return (typeName != L"") ? typeName : m_Type;
+  std::wstring typeName = type ? s2ws(type->GetName()) : L"";
+  return !typeName.empty() ? typeName : m_Type;
 }
 
 //-----------------------------------------------------------------------------
 Variable::BasicType Variable::GetBasicType() {
   // TODO: split assignation and get...
   const Type* type = GetType();
-  Variable::BasicType basicType = type && type->m_Name != L""
-                                      ? Variable::TypeFromString(type->m_Name)
-                                      : Variable::TypeFromString(m_Type);
+  Variable::BasicType basicType =
+      type && !type->m_Name.empty()
+          ? Variable::TypeFromString(s2ws(type->m_Name))
+          : Variable::TypeFromString(m_Type);
   m_BasicType = basicType;
   return m_BasicType;
 }

--- a/OrbitCore/Variable.h
+++ b/OrbitCore/Variable.h
@@ -8,6 +8,7 @@
 #include "BaseTypes.h"
 #include "SerializationMacros.h"
 #include "Utils.h"
+#include "absl/strings/str_format.h"
 
 class Pdb;
 class Type;
@@ -59,12 +60,13 @@ class Variable {
   };
 
   Variable();
-  std::wstring ToString() const {
-    return Format(L"%s %s [%I64u] Size: %lu", m_Type.c_str(), m_Name.c_str(),
-                  m_Address, m_Size);
+  std::string ToString() const {
+    return absl::StrFormat("%s %s [%" PRIu64 "] Size: %lu", m_Type.c_str(),
+                           m_Name.c_str(), m_Address, m_Size);
   }
-  inline const std::wstring& FilterString();
-  void SetType(const std::wstring& a_Type);
+
+  inline const std::string& FilterString();
+  void SetType(const std::string& a_Type);
   void SendValue();
   void SyncValue();
   void ReceiveValue(const Message& a_Msg);
@@ -76,7 +78,7 @@ class Variable {
   void Populate();
   const Type* GetType() const;
   Type* GetType();
-  std::wstring GetTypeName() const;
+  std::string GetTypeName() const;
   Variable::BasicType GetBasicType();
   void UpdateTypeFromString() { m_BasicType = TypeFromString(m_Type); }
   bool IsBasicType() const { return m_BasicType != Invalid; }
@@ -87,9 +89,9 @@ class Variable {
   bool HasChildren() const { return m_Children.size() > 0; }
 
   static std::shared_ptr<Variable> FindVariable(
-      std::shared_ptr<Variable> a_Variable, const std::wstring& a_Name);
-  std::shared_ptr<Variable> FindImmediateChild(const std::wstring& a_Name);
-  static Variable::BasicType TypeFromString(const std::wstring& a_String);
+      std::shared_ptr<Variable> a_Variable, const std::string& a_Name);
+  std::shared_ptr<Variable> FindImmediateChild(const std::string& a_Name);
+  static Variable::BasicType TypeFromString(const std::string& a_String);
 
   //-------------------------------------------------------------------------
   template <typename T>
@@ -131,12 +133,12 @@ class Variable {
     wchar_t m_WChar;
   };
 
-  std::wstring m_Name;
-  std::wstring m_PrettyTypeName;
-  std::wstring m_Type;
-  std::wstring m_Function;
-  std::wstring m_File;
-  std::wstring m_FilterString;
+  std::string m_Name;
+  std::string m_PrettyTypeName;
+  std::string m_Type;
+  std::string m_Function;
+  std::string m_File;
+  std::string m_FilterString;
 
   uint64_t m_Address = 0;
   uint64_t m_BaseOffset = 0;
@@ -157,16 +159,15 @@ class Variable {
 
   std::vector<char> m_RawData;
   std::string m_String;
-  std::wstring m_WideString;
 
   ORBIT_SERIALIZABLE;
 };
 
 //-----------------------------------------------------------------------------
-inline const std::wstring& Variable::FilterString() {
+inline const std::string& Variable::FilterString() {
   if (m_FilterString.size() == 0) {
     m_FilterString =
-        ToLower(m_Name) + L" " + ToLower(m_File) + L" " + ToLower(m_Type);
+        ToLower(m_Name) + " " + ToLower(m_File) + " " + ToLower(m_Type);
   }
 
   return m_FilterString;

--- a/OrbitGl/GlobalDataView.cpp
+++ b/OrbitGl/GlobalDataView.cpp
@@ -184,7 +184,8 @@ void GlobalsDataView::OnAddToWatch(std::vector<int>& a_Items) {
 
     Type* type = variable.GetType();
     if (type && type->HasMembers()) {
-      var = type->GenerateVariable(variable.m_Address, &variable.m_Name);
+      std::string name = ws2s(variable.m_Name);
+      var = type->GenerateVariable(variable.m_Address, &name);
       var->Print();
     } else {
       var = std::make_shared<Variable>(variable);

--- a/OrbitGl/ImGuiOrbit.cpp
+++ b/OrbitGl/ImGuiOrbit.cpp
@@ -643,7 +643,7 @@ void WatchWindow::Draw(const char* title, bool* p_opened) {
                                                // here we add vertical spacing
                                                // to make the tree lines equal
                                                // high.
-      ImGui::Text("%s", ws2s(var.m_Name).c_str());
+      ImGui::Text("%s", var.m_Name.c_str());
       ImGui::NextColumn();
       ImGui::AlignFirstTextHeightToWidgets();
 

--- a/OrbitGl/RuleEditor.cpp
+++ b/OrbitGl/RuleEditor.cpp
@@ -62,8 +62,7 @@ std::shared_ptr<Variable> RuleEditorWindow::GetLastVariable(
 
     for (size_t i = tokens[0] == "this" ? 1 : 0;
          var && type && i < tokens.size(); ++i) {
-      std::wstring varName = s2ws(tokens[i]);
-      std::shared_ptr<Variable> child = var->FindImmediateChild(varName);
+      std::shared_ptr<Variable> child = var->FindImmediateChild(tokens[i]);
       if (child) {
         var = child;
       }
@@ -99,7 +98,7 @@ void RuleEditorWindow::RefreshAutoComplete(const std::string& a_Line) {
       std::string currentWord = GetCurrentWord(a_Line);
       for (auto& pair : type->m_DataMembers) {
         Variable& var = pair.second;
-        std::string varName = ws2s(var.m_Name);
+        const std::string& varName = var.m_Name;
 
         if (Contains(varName, currentWord)) {
           m_AutoComplete.push_back(varName);
@@ -426,7 +425,7 @@ void RuleEditorWindow::Draw(const char* title, bool* p_opened, ImVec2* a_Size) {
   }
 
   if (m_LastVariable) {
-    std::string typeName = ws2s(m_LastVariable->GetTypeName());
+    const std::string& typeName = m_LastVariable->GetTypeName();
     ImGui::Text("Type: %s\nLength: %i\nOffset:%i", typeName.c_str(),
                 (int)m_LastVariable->m_Size, (int)m_LastVariable->m_Address);
   }
@@ -607,7 +606,7 @@ void RuleEditor::OnReceiveMessage(const Message& a_Message) {
 void RuleEditor::ProcessVariable(const std::shared_ptr<Variable> a_Variable,
                                  char* a_Data) {
   if (a_Variable->m_Size == 4) {
-    GCardContainer.Update(ws2s(a_Variable->m_Name), *((float*)a_Data));
+    GCardContainer.Update(a_Variable->m_Name, *((float*)a_Data));
   }
 }
 

--- a/OrbitQt/orbitwatchwidget.cpp
+++ b/OrbitQt/orbitwatchwidget.cpp
@@ -202,23 +202,23 @@ QtProperty* OrbitWatchWidget::AddProp(QtProperty* a_Parent,
                                       const Variable* a_Variable) {
   QtAbstractPropertyManager* manager = GetManager(a_Variable);
   QtProperty* newProperty = nullptr;
-  std::wstring typeName = a_Variable->m_Type == L"" ? a_Variable->GetTypeName()
+  std::string typeName = a_Variable->m_Type.empty() ? a_Variable->GetTypeName()
                                                     : a_Variable->m_Type;
 
   if (a_Variable->m_Children.size()) {
     newProperty =
-        groupManager->addProperty(QString::fromStdWString(a_Variable->m_Name));
+        groupManager->addProperty(QString::fromStdString(a_Variable->m_Name));
 
     for (std::shared_ptr<Variable> member : a_Variable->m_Children) {
       QtProperty* prop = AddProp(newProperty, member.get());
       newProperty->addSubProperty(prop);
     }
 
-    newProperty->setPropertyType(QString::fromStdWString(typeName));
+    newProperty->setPropertyType(QString::fromStdString(typeName));
   } else {
     newProperty =
-        manager->addProperty(QString::fromStdWString(a_Variable->m_Name));
-    newProperty->setPropertyType(QString::fromStdWString(typeName));
+        manager->addProperty(QString::fromStdString(a_Variable->m_Name));
+    newProperty->setPropertyType(QString::fromStdString(typeName));
     newProperty->SetUserData((void*)a_Variable);
 
     AddToMap(a_Variable, newProperty);

--- a/external/DIA2Dump/PrintSymbol.cpp
+++ b/external/DIA2Dump/PrintSymbol.cpp
@@ -604,29 +604,29 @@ void PrintGlobalSymbol(IDiaSymbol* pSymbol)
     }
 }
 
-std::wstring GetBasicType(DWORD a_BaseType)
+std::string GetBasicType(DWORD a_BaseType)
 {
-    static std::unordered_map<DWORD, std::wstring> BasicTypeMap;
+    static std::unordered_map<DWORD, std::string> BasicTypeMap;
     if (BasicTypeMap.size() == 0)
     {
-        BasicTypeMap[btNoType]  = L"btNoType  ";
-        BasicTypeMap[btVoid]    = L"void";
-        BasicTypeMap[btChar]    = L"char";
-        BasicTypeMap[btWChar]   = L"wchar_t";
-        BasicTypeMap[btInt]     = L"int";
-        BasicTypeMap[btUInt]    = L"unsigned __int32";
-        BasicTypeMap[btFloat]   = L"float";
-        BasicTypeMap[btBCD]     = L"btBCD";
-        BasicTypeMap[btBool]    = L"bool";
-        BasicTypeMap[btLong]    = L"long";
-        BasicTypeMap[btULong]   = L"unsigned long";
-        BasicTypeMap[btCurrency]= L"btCurrency";
-        BasicTypeMap[btDate]    = L"btDate";
-        BasicTypeMap[btVariant] = L"btVariant";
-        BasicTypeMap[btComplex] = L"btComplex";
-        BasicTypeMap[btBit]     = L"btBit";
-        BasicTypeMap[btBSTR]    = L"btBSTR";
-        BasicTypeMap[btHresult] = L"btHresult";
+        BasicTypeMap[btNoType]  = "btNoType  ";
+        BasicTypeMap[btVoid]    = "void";
+        BasicTypeMap[btChar]    = "char";
+        BasicTypeMap[btWChar]   = "wchar_t";
+        BasicTypeMap[btInt]     = "int";
+        BasicTypeMap[btUInt]    = "unsigned __int32";
+        BasicTypeMap[btFloat]   = "float";
+        BasicTypeMap[btBCD]     = "btBCD";
+        BasicTypeMap[btBool]    = "bool";
+        BasicTypeMap[btLong]    = "long";
+        BasicTypeMap[btULong]   = "unsigned long";
+        BasicTypeMap[btCurrency]= "btCurrency";
+        BasicTypeMap[btDate]    = "btDate";
+        BasicTypeMap[btVariant] = "btVariant";
+        BasicTypeMap[btComplex] = "btComplex";
+        BasicTypeMap[btBit]     = "btBit";
+        BasicTypeMap[btBSTR]    = "btBSTR";
+        BasicTypeMap[btHresult] = "btHresult";
     }
 
     return BasicTypeMap[a_BaseType];
@@ -684,13 +684,13 @@ void OrbitAddGlobalSymbol(IDiaSymbol* pSymbol)
             if (pSymbol->get_undecoratedName(&bstrUndname) == S_OK)
             {
                 //LOGF(L"%s(%s)\n", bstrName, bstrUndname);
-                Var.m_Name = bstrUndname;
+                Var.m_Name = ws2s(bstrUndname);
                 SysFreeString(bstrUndname);
             }
             else
             {
                 //LOGF(L"%s\n", bstrName);
-                Var.m_Name = bstrName;
+                Var.m_Name = ws2s(bstrName);
             }
 
             SysFreeString(bstrName);
@@ -705,7 +705,7 @@ void OrbitAddGlobalSymbol(IDiaSymbol* pSymbol)
             BSTR bstrTypeName;
             if (globalType.m_Symbol->get_name(&bstrTypeName) == S_OK)
             {
-                Var.SetType(bstrTypeName);
+                Var.SetType(ws2s(bstrTypeName));
             }
 
             DWORD baseType;
@@ -736,7 +736,7 @@ void OrbitAddGlobalSymbol(IDiaSymbol* pSymbol)
         BSTR bstrFile;
         if (pSymbol->get_sourceFileName(&bstrFile) == S_OK)
         {
-            Var.m_File = bstrFile;
+            Var.m_File = ws2s(bstrFile);
         }
 
         //Var.SetType( ws2s(szTypeName) );
@@ -2018,11 +2018,11 @@ void GetData( IDiaSymbol* pSymbol, Type* a_OrbitType )
         if( pSymbol->get_offset( &lOffset ) == S_OK )
         {
             Variable member;
-            member.m_Name = GetName( pSymbol );
+            member.m_Name = ws2s(GetName( pSymbol ));
             member.m_Size = (ULONG)GetSize( pSymbol );
             member.m_TypeIndex = GetTypeID( pSymbol );
-            member.m_Type = GetSymbolType( pSymbol );
-            member.m_PrettyTypeName = GetData( pSymbol );
+            member.m_Type = ws2s(GetSymbolType( pSymbol ));
+            member.m_PrettyTypeName = ws2s(GetData( pSymbol ));
             member.m_Pdb = a_OrbitType->m_Pdb;
             a_OrbitType->m_DataMembers[lOffset] = member;
             LOGF( L"this+0x%X", lOffset );

--- a/external/DIA2Dump/dia2dump.cpp
+++ b/external/DIA2Dump/dia2dump.cpp
@@ -929,11 +929,11 @@ bool DumpTypes(IDiaSymbol *pGlobal)
         BSTR bstrName;
         if( pSymbol->get_name( &bstrName ) != S_OK )
         {
-            orbitType.m_Name = L"???";
+            orbitType.m_Name = "???";
         }
         else
         {
-            orbitType.m_Name = bstrName;
+            orbitType.m_Name = ws2s(bstrName);
             SysFreeString( bstrName );
         }
 


### PR DESCRIPTION
The goal of these series of changes is to remove wstring
from ORBIT code base to then use abseil for all string
operations.

Test: cmake --build .