### PR TITLE
Remove unused OrbitRule

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -97,7 +97,6 @@ target_sources(
           OrbitLib.cpp
           OrbitModule.cpp
           OrbitProcess.cpp
-          OrbitRule.cpp
           OrbitSession.cpp
           OrbitThread.cpp
           OrbitType.cpp

--- a/OrbitCore/OrbitRule.h
+++ b/OrbitCore/OrbitRule.h
@@ -19,11 +19,3 @@ class Rule {
   bool m_TrackReturnValue;
   std::vector<std::shared_ptr<Variable>> m_TrackedVariables;
 };
-
-class OrbitRule {
-  std::wstring m_FunctionName;
-  std::vector<std::wstring> m_Variables;
-
-  bool m_TrackArguments;
-  bool m_TrackReturnValue;
-};


### PR DESCRIPTION
There are no references in the code to this class.

Test: cmake --build .