### PR TITLE
Pdb: wstring->string migration

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -95,8 +95,8 @@ bool Capture::Inject(bool a_WaitForConnection) {
 
   GInjected = inject.Inject(s2ws(dllName), *GTargetProcess, "OrbitInit");
   if (GInjected) {
-    ORBIT_LOG(absl::StrFormat("Injected in %s",
-                              GTargetProcess->GetName().c_str()));
+    ORBIT_LOG(
+        absl::StrFormat("Injected in %s", GTargetProcess->GetName().c_str()));
     GInjectedProcess = GTargetProcess->GetName();
     GInjectedProcessW = s2ws(GInjectedProcess);
   }
@@ -121,12 +121,11 @@ bool Capture::InjectRemote() {
   std::string dllName = Path::GetDllPath(GTargetProcess->GetIs64Bit());
   GTcpServer->Disconnect();
 
-  GInjected =
-      inject.Inject(s2ws(dllName), *GTargetProcess, "OrbitInitRemote");
+  GInjected = inject.Inject(s2ws(dllName), *GTargetProcess, "OrbitInitRemote");
 
   if (GInjected) {
-    ORBIT_LOG(absl::StrFormat("Injected in %s",
-                              GTargetProcess->GetName().c_str()));
+    ORBIT_LOG(
+        absl::StrFormat("Injected in %s", GTargetProcess->GetName().c_str()));
     GInjectedProcess = GTargetProcess->GetName();
     GInjectedProcessW = s2ws(GInjectedProcess);
   }
@@ -535,8 +534,8 @@ void Capture::SaveSession(const std::wstring& a_FileName) {
 
   for (Function* func : GTargetProcess->GetFunctions()) {
     if (func->IsSelected()) {
-      session.m_Modules[func->m_Pdb->GetName()].m_FunctionHashes.push_back(
-          func->Hash());
+      session.m_Modules[s2ws(func->m_Pdb->GetName())]
+          .m_FunctionHashes.push_back(func->Hash());
     }
   }
 
@@ -545,8 +544,8 @@ void Capture::SaveSession(const std::wstring& a_FileName) {
     saveFileName += ".opr";
   }
 
-  SCOPE_TIMER_LOG(absl::StrFormat("Saving Orbit session in %s",
-                                  saveFileName.c_str()));
+  SCOPE_TIMER_LOG(
+      absl::StrFormat("Saving Orbit session in %s", saveFileName.c_str()));
   std::ofstream file(saveFileName, std::ios::binary);
   cereal::BinaryOutputArchive archive(file);
   archive(cereal::make_nvp("Session", session));

--- a/OrbitCore/LinuxEventTracer.cpp
+++ b/OrbitCore/LinuxEventTracer.cpp
@@ -59,13 +59,13 @@ void LinuxEventTracerThread::Run(
     for (const auto& function : instrumented_functions_) {
       for (int32_t cpu = 0; cpu < num_cpus_; cpu++) {
         int uprobe_fd = LinuxPerfUtils::uprobe_stack_event_open(
-            ws2s(function->m_Pdb->GetFileName()).c_str(), function->m_Address,
+            function->m_Pdb->GetFileName().c_str(), function->m_Address,
             -1, cpu);
         fds.push_back(uprobe_fd);
         uprobe_fds_to_function[uprobe_fd] = function;
 
         int uretprobe_fd = LinuxPerfUtils::uretprobe_stack_event_open(
-            ws2s(function->m_Pdb->GetFileName()).c_str(), function->m_Address,
+            function->m_Pdb->GetFileName().c_str(), function->m_Address,
             -1, cpu);
         fds.push_back(uretprobe_fd);
         uretprobe_fds_to_function[uretprobe_fd] = function;

--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -104,7 +104,7 @@ DWORD64 Function::GetVirtualAddress() const {
 //-----------------------------------------------------------------------------
 std::wstring Function::GetModuleName() {
   if (m_Pdb) {
-    return m_Pdb->GetName();
+    return s2ws(m_Pdb->GetName());
   } else {
     std::shared_ptr<Module> module =
         Capture::GTargetProcess->GetModuleFromAddress(m_Address);

--- a/OrbitCore/OrbitModule.h
+++ b/OrbitCore/OrbitModule.h
@@ -17,7 +17,7 @@ class Pdb;
 struct Module {
   Module();
 
-  std::wstring GetPrettyName();
+  std::string GetPrettyName();
   bool IsDll() const;
   bool LoadDebugInfo();
   bool ContainsAddress(uint64_t a_Address) {

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -392,7 +392,7 @@ void Process::FillModuleDebugInfo(ModuleDebugInfo& a_ModuleDebugInfo) {
   if (module) {
     PRINT_VAR(module->m_FullName);
     module->LoadDebugInfo();
-    std::wstring moduleName = s2ws(module->m_FullName);
+    const std::string& moduleName = module->m_FullName;
     module->m_Pdb->LoadPdb(moduleName.c_str());
     a_ModuleDebugInfo.m_Functions = module->m_Pdb->GetFunctions();
   } else {

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -20,18 +20,20 @@ struct IDiaDataSource;
 
 class Pdb {
  public:
-  Pdb(const wchar_t* a_PdbName = L"");
+  explicit Pdb(const char* pdb_name = "");
+  Pdb(const Pdb&) = delete;
+  Pdb& operator=(const Pdb&) = delete;
   ~Pdb();
 
   void Init();
 
-  virtual bool LoadPdb(const wchar_t* a_PdbName);
-  virtual void LoadPdbAsync(const wchar_t* a_PdbName,
+  virtual bool LoadPdb(const char* a_PdbName);
+  virtual void LoadPdbAsync(const char* a_PdbName,
                             std::function<void()> a_CompletionCallback);
 
   bool LoadDataFromPdb();
   bool LoadPdbDia();
-  bool LoadLinuxDebugSymbols(const wchar_t* a_PdbName);
+  bool LoadLinuxDebugSymbols(const char* a_PdbName);
   void Update();
   void AddFunction(Function& a_Function);
   void CheckOrbitFunction(Function& a_Function);
@@ -42,8 +44,8 @@ class Pdb {
   void AddArgumentRegister(const std::string& a_Reg,
                            const std::string& a_Function);
 
-  const std::wstring& GetName() const { return m_Name; }
-  const std::wstring& GetFileName() const { return m_FileName; }
+  const std::string& GetName() const { return m_Name; }
+  const std::string& GetFileName() const { return m_FileName; }
   std::vector<Function>& GetFunctions() { return m_Functions; }
   std::vector<Type>& GetTypes() { return m_Types; }
   std::vector<Variable>& GetGlobals() { return m_Globals; }
@@ -71,8 +73,8 @@ class Pdb {
   void SetLoadTime(float a_LoadTime) { m_LastLoadTime = a_LoadTime; }
   float GetLoadTime() { return m_LastLoadTime; }
 
-  std::wstring GetCachedName();
-  std::wstring GetCachedKey();
+  std::string GetCachedName();
+  std::string GetCachedKey();
   bool Load(const std::string& a_CachedPdb);
   void Save();
 
@@ -112,8 +114,8 @@ class Pdb {
   std::map<std::string, std::vector<std::string> > m_RegFunctionsMap;
 
   // Data
-  std::wstring m_Name;
-  std::wstring m_FileName;
+  std::string m_Name;
+  std::string m_FileName;
   std::vector<Function> m_Functions;
   std::vector<Type> m_Types;
   std::vector<Variable> m_Globals;
@@ -132,17 +134,15 @@ class Pdb {
 #else
 class Pdb {
  public:
-  // TODO: these constructors seem to be not usefull
-  Pdb(const wchar_t* a_PdbName) {}
-  Pdb(const char* a_PdbName) {}
-  Pdb() {}
-  ~Pdb() {}
+  Pdb() = default;
+  Pdb(const Pdb&) = delete;
+  Pdb& operator=(const Pdb&) = delete;
 
   void Init() {}
 
-  virtual bool LoadPdb(const wchar_t* a_PdbName);
-  virtual void LoadPdbAsync(const wchar_t* a_PdbName,
-                            std::function<void()> a_CompletionCallback);
+  virtual bool LoadPdb(const char* pdb_name);
+  virtual void LoadPdbAsync(const char* pdb_name,
+                            std::function<void()> completion_callback);
 
   bool LoadDataFromPdb() { return LoadPdb(m_Name.c_str()); }
   bool LoadPdbDia() { return false; }
@@ -156,8 +156,8 @@ class Pdb {
   void AddArgumentRegister(const std::string& a_Reg,
                            const std::string& a_Function) {}
 
-  const std::wstring& GetName() const { return m_Name; }
-  const std::wstring& GetFileName() const { return m_FileName; }
+  const std::string& GetName() const { return m_Name; }
+  const std::string& GetFileName() const { return m_FileName; }
   std::vector<Function>& GetFunctions() { return m_Functions; }
   std::vector<Type>& GetTypes() { return m_Types; }
   std::vector<Variable>& GetGlobals() { return m_Globals; }
@@ -186,8 +186,8 @@ class Pdb {
   void SetLoadTime(float a_LoadTime) { m_LastLoadTime = a_LoadTime; }
   float GetLoadTime() { return m_LastLoadTime; }
 
-  std::wstring GetCachedName();
-  std::wstring GetCachedKey();
+  std::string GetCachedName();
+  std::string GetCachedKey();
   bool Load(const std::string& a_CachedPdb);
   void Save();
 
@@ -217,8 +217,8 @@ class Pdb {
   std::map<std::string, std::vector<std::string> > m_RegFunctionsMap;
 
   // Data
-  std::wstring m_Name;
-  std::wstring m_FileName;
+  std::string m_Name;
+  std::string m_FileName;
   std::vector<Function> m_Functions;
   std::vector<Type> m_Types;
   std::vector<Variable> m_Globals;

--- a/OrbitGl/CaptureSerializer.cpp
+++ b/OrbitGl/CaptureSerializer.cpp
@@ -130,7 +130,7 @@ void CaptureSerializer::Load(const std::wstring a_FileName) {
     // functions
     std::shared_ptr<Module> module = std::make_shared<Module>();
     Capture::GTargetProcess->AddModule(module);
-    module->m_Pdb = std::make_shared<Pdb>(a_FileName.c_str());
+    module->m_Pdb = std::make_shared<Pdb>(ws2s(a_FileName).c_str());
     archive(module->m_Pdb->GetFunctions());
     module->m_Pdb->ProcessData();
     GPdbDbg = module->m_Pdb;

--- a/OrbitGl/FunctionDataView.cpp
+++ b/OrbitGl/FunctionDataView.cpp
@@ -96,7 +96,7 @@ std::wstring FunctionsDataView::GetValue(int a_Row, int a_Column) {
       value = function.m_File;
       break;
     case Function::MODULE:
-      value = function.m_Pdb ? ws2s(function.m_Pdb->GetName()) : "";
+      value = function.m_Pdb ? function.m_Pdb->GetName() : "";
       break;
     case Function::LINE:
       value = absl::StrFormat("%i", function.m_Line);
@@ -246,12 +246,12 @@ void FunctionsDataView::OnFilter(const std::wstring& a_Filter) {
   std::vector<Function*>& functions = Capture::GTargetProcess->GetFunctions();
   for (int i = 0; i < (int)functions.size(); ++i) {
     Function* function = functions[i];
-    std::wstring name = s2ws(function->Lower()) + function->m_Pdb->GetName();
+    std::string name = function->Lower() + function->m_Pdb->GetName();
 
     bool match = true;
 
     for (std::wstring& filterToken : tokens) {
-      if (name.find(filterToken) == std::string::npos) {
+      if (name.find(ws2s(filterToken)) == std::string::npos) {
         match = false;
         break;
       }

--- a/OrbitGl/GlobalDataView.cpp
+++ b/OrbitGl/GlobalDataView.cpp
@@ -87,7 +87,7 @@ std::wstring GlobalsDataView::GetValue(int a_Row, int a_Column) {
       value = variable.m_File;
       break;
     case Variable::MODULE:
-      value = ws2s(variable.m_Pdb->GetName());
+      value = variable.m_Pdb->GetName();
       break;
     /*case Variable::MODBASE:
         value = wxString::Format("0x%I64x", function.m_ModBase);  break;*/

--- a/OrbitGl/LiveFunctionDataView.cpp
+++ b/OrbitGl/LiveFunctionDataView.cpp
@@ -133,7 +133,7 @@ std::wstring LiveFunctionsDataView::GetValue(int a_Row, int a_Column) {
               : "";
       break;
     case LiveFunction::MODULE:
-      value = function.m_Pdb ? ws2s(function.m_Pdb->GetName()) : "";
+      value = function.m_Pdb ? function.m_Pdb->GetName() : "";
       break;
     default:
       break;

--- a/OrbitGl/ModuleDataView.cpp
+++ b/OrbitGl/ModuleDataView.cpp
@@ -191,12 +191,12 @@ void ModulesDataView::OnFilter(const std::wstring& a_Filter) {
 
   for (int i = 0; i < (int)m_Modules.size(); ++i) {
     std::shared_ptr<Module>& module = m_Modules[i];
-    std::wstring name = ToLower(module->GetPrettyName());
+    std::string name = ToLower(module->GetPrettyName());
 
     bool match = true;
 
     for (std::wstring& filterToken : tokens) {
-      if (name.find(filterToken) == std::string::npos) {
+      if (name.find(ws2s(filterToken)) == std::string::npos) {
         match = false;
         break;
       }

--- a/OrbitGl/TypeDataView.cpp
+++ b/OrbitGl/TypeDataView.cpp
@@ -122,7 +122,7 @@ std::wstring TypesDataView::GetValue(int a_Row, int a_Column) {
       value = absl::StrFormat("%d", type.m_BaseOffset);
       break;
     case Type::MODULE:
-      value = ws2s(type.m_Pdb->GetName());
+      value = type.m_Pdb->GetName();
       break;
     default:
       break;


### PR DESCRIPTION
The goal of these series of changes is to remove wstring
from ORBIT code base to then use abseil for all string
operations.

Test: cmake --build .