### PR TITLE
Thread name is a string now

### DIFF
--- a/OrbitCore/Hijacking.cpp
+++ b/OrbitCore/Hijacking.cpp
@@ -80,7 +80,7 @@ struct ThreadLocalData {
     }
   }
 
-  std::wstring m_ThreadName;
+  std::string m_ThreadName;
   std::vector<ReturnAddress> m_ReturnAdresses;
   std::vector<Timer> m_Timers;
   std::vector<const Context*> m_Contexts;

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -154,7 +154,7 @@ void Process::EnumerateThreads() {
             std::shared_ptr<Thread> thread = std::make_shared<Thread>();
             thread->m_Handle = thandle;
             thread->m_TID = te.th32ThreadID;
-            m_ThreadNames[thread->m_TID] = ws2s(GetThreadName(thandle));
+            m_ThreadNames[thread->m_TID] = GetThreadName(thandle);
             m_Threads.push_back(thread);
           }
         }

--- a/OrbitCore/TcpServer.cpp
+++ b/OrbitCore/TcpServer.cpp
@@ -160,10 +160,8 @@ void TcpServer::Receive(const Message& a_Message) {
       break;
     }
     case Msg_ThreadInfo: {
-      // TODO: get rid of wchar_t
-      std::wstring threadName((wchar_t*)a_Message.GetData());
-      Capture::GTargetProcess->SetThreadName(a_Message.m_ThreadId,
-                                             ws2s(threadName));
+      std::string threadName(a_Message.GetData());
+      Capture::GTargetProcess->SetThreadName(a_Message.m_ThreadId, threadName);
       PRINT_VAR(threadName);
       break;
     }

--- a/OrbitCore/Threading.h
+++ b/OrbitCore/Threading.h
@@ -26,6 +26,8 @@
 using oqpi_tk = oqpi::default_helpers;
 #endif
 
+#include "Utils.h"
+
 // Typedefs
 typedef std::recursive_mutex Mutex;
 typedef std::lock_guard<std::recursive_mutex> ScopeLock;
@@ -57,13 +59,13 @@ inline void SetCurrentThreadName(const wchar_t* a_ThreadName) {
 }
 
 //-----------------------------------------------------------------------------
-inline std::wstring GetThreadName(HANDLE a_Thread) {
-  std::wstring name;
+inline std::string GetThreadName(HANDLE a_Thread) {
+  std::string name;
   PWSTR data = nullptr;
   HRESULT hr = GetThreadDescription(a_Thread, &data);
 
   if (SUCCEEDED(hr)) {
-    name = data;
+    name = ws2s(data);
     LocalFree(data);
   }
 
@@ -71,7 +73,7 @@ inline std::wstring GetThreadName(HANDLE a_Thread) {
 }
 
 //-----------------------------------------------------------------------------
-inline std::wstring GetCurrentThreadName() {
+inline std::string GetCurrentThreadName() {
   return GetThreadName(GetCurrentThread());
 }
 


### PR DESCRIPTION
The goal of these series of changes is to remove wstring
from ORBIT code base to then use abseil for all string
operations.

Test: cmake --build .