### PR TITLE
FunctionParam fields are strings now

### DIFF
--- a/OrbitCore/OrbitFunction.cpp
+++ b/OrbitCore/OrbitFunction.cpp
@@ -241,8 +241,8 @@ bool FunctionParam::InRegister(int a_Index) { return a_Index < 4; }
 
 //-----------------------------------------------------------------------------
 bool FunctionParam::IsFloat() {
-  return (m_Type.find(TEXT("float")) != std::wstring::npos ||
-          m_Type.find(TEXT("double")) != std::wstring::npos);
+  return (m_Type.find("float") != std::string::npos ||
+          m_Type.find("double") != std::string::npos);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -22,18 +22,18 @@ class Pdb;
 //-----------------------------------------------------------------------------
 struct FunctionParam {
   FunctionParam();
-  std::wstring m_Name;
-  std::wstring m_ParamType;
-  std::wstring m_Type;
-  std::wstring m_Address;
+  std::string m_Name;
+  std::string m_ParamType;
+  std::string m_Type;
+  std::string m_Address;
 
 #ifdef _WIN32
   SYMBOL_INFO m_SymbolInfo;
 #endif
 
   bool InRegister(int a_Index);
-  bool IsPointer() { return m_Type.find(L"*") != std::wstring::npos; }
-  bool IsRef() { return m_Type.find(L"&") != std::wstring::npos; }
+  bool IsPointer() { return m_Type.find("*") != std::string::npos; }
+  bool IsRef() { return m_Type.find("&") != std::string::npos; }
   bool IsFloat();
 };
 


### PR DESCRIPTION
The goal of these series of changes is to remove wstring
from ORBIT code base to then use abseil for all string
operations.

Test: cmake --build .