### PR TITLE
Remove PRINT("Error: Callstacks can only be added while sampling.\n")

### DIFF
--- a/OrbitCore/SamplingProfiler.cpp
+++ b/OrbitCore/SamplingProfiler.cpp
@@ -144,9 +144,6 @@ void SamplingProfiler::AddCallStack(CallStack& a_CallStack) {
 
 //-----------------------------------------------------------------------------
 void SamplingProfiler::AddHashedCallStack(CallstackEvent& a_CallStack) {
-  if (m_State != Sampling) {
-    PRINT("Error: Callstacks can only be added while sampling.\n");
-  }
   if (!HasCallStack(a_CallStack.m_Id)) {
     PRINT(
         "Error: Callstacks can only be added by hash when they are already "


### PR DESCRIPTION
As we are buffering callstacks to process them in order, this is normal
behavior. Let's remove the print to avoid producing tons of these messages at
the end of a tracing session.