### PR TITLE
Fix UI not connecting to service (and crashing) if service is started after UI

### DIFF
--- a/OrbitCore/TcpClient.cpp
+++ b/OrbitCore/TcpClient.cpp
@@ -149,7 +149,6 @@ void TcpClient::OnError(const std::error_code& ec) {
   OutputDebugStringW(L"Closing socket\n");
   m_IsValid = false;
   Stop();
-  Orbit::DeInit();
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitCore/TcpEntity.cpp
+++ b/OrbitCore/TcpEntity.cpp
@@ -30,15 +30,14 @@ TcpEntity::~TcpEntity() {}
 //-----------------------------------------------------------------------------
 void TcpEntity::Start() {
   PRINT_FUNC;
+  m_ExitRequested = false;
   m_SenderThread = new std::thread([&]() { SendData(); });
 }
 
 //-----------------------------------------------------------------------------
 void TcpEntity::Stop() {
   PRINT_FUNC;
-  if (!m_ExitRequested) {
-    m_ExitRequested = true;
-  }
+  m_ExitRequested = true;
 
   m_ConditionVariable.signal();
   if (m_SenderThread != nullptr) {


### PR DESCRIPTION
This includes fixing the reconnection of the UI to the service if the service is
closed and reopened without closing and reopening the UI.