### PR TITLE
Copy prebuild artefacts into sourcetree and add flags for parallel builds in VS.

### DIFF
--- a/bootstrap-ci-orbit.bat
+++ b/bootstrap-ci-orbit.bat
@@ -6,26 +6,17 @@ set ORBIT_VS_VERSION=142
 :: This is appended to the toolchain files for vcpkg and Orbit itself below.
 set ORBIT_WINSDK_VERSION="10.0.18362.0"
 
-:: Build vcpkg
 call git submodule update --init
-cd external/vcpkg
-
-if exist "vcpkg.exe" (
-    echo found vcpkg.exe
-) else (
-    echo set^(VCPKG_PLATFORM_TOOLSET v%ORBIT_VS_VERSION%^) >> triplets\x64-windows.cmake
-    echo set^(CMAKE_SYSTEM_VERSION %ORBIT_WINSDK_VERSION%^) >> triplets\x64-windows.cmake
-    call ./bootstrap-vcpkg.bat
-)
-
-:: Build dynamic dependencies
-set VCPKG_DEFAULT_TRIPLET=x64-windows
-vcpkg install abseil freeglut glew freetype freetype-gl curl breakpad capstone asio cereal imgui qt5-base gtest
-
-cd ..\..
+:: Copy vcpkg stuff instead of building it.
+robocopy C:\vcpkg\scripts external\vcpkg\scripts /s /e /njh /njs /ndl /nc /ns /NFL
+robocopy C:\vcpkg\packages external\vcpkg\packages /s /e /njh /njs /ndl /nc /ns /NFL
+robocopy C:\vcpkg\installed external\vcpkg\installed /s /e /njh /njs /ndl /nc /ns /NFL
+robocopy C:\vcpkg\downloads external\vcpkg\downloads /s /e /njh /njs /ndl /nc /ns /NFL
+mkdir external\vcpkg\buildtrees
+robocopy C:\vcpkg\buildtrees\freetype-gl external\vcpkg\buildtrees\freetype-gl /s /e /njh /njs /ndl /nc /ns /NFL
+robocopy C:\vcpkg\buildtrees\breakpad external\vcpkg\buildtrees\breakpad /s /e /njh /njs /ndl /nc /ns /NFL
 
 :: Fix breakpad missing file
-copy "external\vcpkg\buildtrees\breakpad\src\f427f61ed3-fe83a49e5d\src\processor\linked_ptr.h" "external\vcpkg\installed\x86-windows\include\google_breakpad\processor\linked_ptr.h" /y
 copy "external\vcpkg\buildtrees\breakpad\src\f427f61ed3-fe83a49e5d\src\processor\linked_ptr.h" "external\vcpkg\installed\x64-windows\include\google_breakpad\processor\linked_ptr.h" /y
 
 mkdir build_release_x64

--- a/contrib/toolchains/toolchain-windows-32bit-msvc-debug.cmake
+++ b/contrib/toolchains/toolchain-windows-32bit-msvc-debug.cmake
@@ -11,6 +11,8 @@ add_compile_options(
   /wd4201
   /Zi)
 
+string(APPEND CMAKE_CXX_FLAGS " /MP")
+
 add_link_options(/INCREMENTAL:NO)
 
 # This include expects your build directory to be a direct subdirectory of the

--- a/contrib/toolchains/toolchain-windows-32bit-msvc-release.cmake
+++ b/contrib/toolchains/toolchain-windows-32bit-msvc-release.cmake
@@ -8,6 +8,7 @@ string(APPEND CMAKE_CXX_FLAGS " /wd4245")
 string(APPEND CMAKE_CXX_FLAGS " /wd4244")
 string(APPEND CMAKE_CXX_FLAGS " /wd4481")
 string(APPEND CMAKE_CXX_FLAGS " /wd4201")
+string(APPEND CMAKE_CXX_FLAGS " /MP")
 
 # This include expects your build directory to be a direct subdirectory of the
 # project root.

--- a/contrib/toolchains/toolchain-windows-64bit-msvc-debug.cmake
+++ b/contrib/toolchains/toolchain-windows-64bit-msvc-debug.cmake
@@ -11,6 +11,8 @@ add_compile_options(
   /wd4201
   /Zi)
 
+string(APPEND CMAKE_CXX_FLAGS " /MP")
+
 add_link_options(/INCREMENTAL:NO)
 
 # This include expects your build directory to be a direct subdirectory of the

--- a/contrib/toolchains/toolchain-windows-64bit-msvc-release.cmake
+++ b/contrib/toolchains/toolchain-windows-64bit-msvc-release.cmake
@@ -8,6 +8,7 @@ string(APPEND CMAKE_CXX_FLAGS " /wd4245")
 string(APPEND CMAKE_CXX_FLAGS " /wd4244")
 string(APPEND CMAKE_CXX_FLAGS " /wd4481")
 string(APPEND CMAKE_CXX_FLAGS " /wd4201")
+string(APPEND CMAKE_CXX_FLAGS " /MP")
 
 # This include expects your build directory to be a direct subdirectory of the
 # project root.


### PR DESCRIPTION
Ugly trick to get the CI build in minutes instead of hours. 

This requires me to update the vm building this when we do nontrivial changes to the dependecies. If this hurts at some point I'll look into properly caching this in some persistent storage that gets updated by the build system. 