### PR TITLE
Making OrbitQt/Orbit.exe a proper win32 executable

### DIFF
--- a/OrbitQt/CMakeLists.txt
+++ b/OrbitQt/CMakeLists.txt
@@ -77,6 +77,8 @@ if(WIN32)
     OrbitQt
     PROPERTIES LINK_FLAGS
                "/MANIFESTUAC:\"level='requireAdministrator' /SUBSYSTEM:WINDOWS")
+  set_target_properties(OrbitQt PROPERTIES WIN32_EXECUTABLE ON)
+  target_sources(OrbitQt PRIVATE orbit.rc)
 endif()
 
 set_target_properties(OrbitQt PROPERTIES OUTPUT_NAME "Orbit")

--- a/OrbitQt/orbit.rc
+++ b/OrbitQt/orbit.rc
@@ -1,0 +1,1 @@
+IDI_ICON1               ICON    DISCARDABLE     "orbit.ico"


### PR DESCRIPTION
* By setting the `WIN32_EXECUTABLE` property, the program's entry point is changed
  from "main" to "WinMain" which makes the console window disappear.
* Added a qt resource file, which helps setting the app icon on windows.
