### PR TITLE
Drop dependency on nm/objdump on Linux

### DIFF
--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -224,7 +224,8 @@ target_sources(OrbitCoreTests
 if(NOT WIN32)
   target_sources(OrbitCoreTests
     PRIVATE LinuxPerfEventProcessor2Test.cpp
-            LinuxUprobesUnwindingVisitorTest.cpp)
+            LinuxUprobesUnwindingVisitorTest.cpp
+            OrbitModuleTest.cpp)
 endif()
 
 target_link_libraries(OrbitCoreTests

--- a/OrbitCore/OrbitModuleTest.cpp
+++ b/OrbitCore/OrbitModuleTest.cpp
@@ -1,0 +1,46 @@
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "Path.h"
+#include "Pdb.h"
+
+TEST(OrbitModule, LoadPdb) {
+  std::string executable_path = Path::GetExecutablePath();
+  // This is a simple executable that prints "Hello Earh!"
+  std::string test_elf_file = executable_path + "/testdata/hello_world_elf";
+
+  Pdb pdb;
+  ASSERT_TRUE(pdb.LoadFunctions(test_elf_file.c_str()));
+
+  // Check functions
+  const std::vector<Function>& functions = pdb.GetFunctions();
+
+  EXPECT_EQ(functions.size(), 10);
+  const Function* function = &functions[0];
+
+  EXPECT_EQ(function->Name(), "deregister_tm_clones");
+  EXPECT_EQ(function->PrettyName(), "deregister_tm_clones");
+  EXPECT_EQ(function->Address(), 0x1080);
+  EXPECT_EQ(function->Size(), 0);
+  EXPECT_EQ(function->GetPdb(), &pdb);
+  EXPECT_EQ(function->Probe(), test_elf_file + ":deregister_tm_clones");
+
+  // This function points to .init section and should not have a Probe
+  function = &functions[4];
+  EXPECT_EQ(function->Name(), "_init");
+  EXPECT_EQ(function->PrettyName(), "_init");
+  EXPECT_EQ(function->Address(), 0x1000);
+  EXPECT_EQ(function->Size(), 0);
+  EXPECT_EQ(function->GetPdb(), &pdb);
+  EXPECT_EQ(function->Probe(), "");
+
+  function = &functions[9];
+  EXPECT_EQ(function->Name(), "main");
+  EXPECT_EQ(function->PrettyName(), "main");
+  EXPECT_EQ(function->Address(), 0x1135);
+  EXPECT_EQ(function->Size(), 35);
+  EXPECT_EQ(function->GetPdb(), &pdb);
+  EXPECT_EQ(function->Probe(), test_elf_file + ":main");
+}

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -145,12 +145,13 @@ class Pdb {
 
   void Init() {}
 
-  virtual bool LoadPdb(const char* pdb_name);
+  virtual bool LoadPdb(const char* file_name);
   virtual void LoadPdbAsync(const char* pdb_name,
                             std::function<void()> completion_callback);
 
   bool LoadDataFromPdb() { return LoadPdb(m_Name.c_str()); }
   bool LoadPdbDia() { return false; }
+  bool LoadFunctions(const char* file_name);
   void Update() {}
   void AddFunction(Function& a_Function) { m_Functions.push_back(a_Function); }
   void CheckOrbitFunction(Function& a_Function) {}


### PR DESCRIPTION
Linux version now calls ElfFile in order to lookup symbols and convert them to functions.