### PR TITLE
Add llvm to vckpg list in bootstrap-orbit-ggp.sh

### DIFF
--- a/bootstrap-orbit-ggp.sh
+++ b/bootstrap-orbit-ggp.sh
@@ -25,7 +25,7 @@ fi
 ## Build dependencies
 ./vcpkg --overlay-triplets=../../contrib/vcpkg/triplets/ \
   --triplet x64-linux-ggp install abseil freetype freetype-gl breakpad \
-  capstone asio cereal imgui freeglut glew curl gtest
+  capstone asio cereal imgui freeglut glew curl gtest llvm
 
 if [ $? -ne 0 ]; then
   echo -n "Orbit: Could not install all the dependencies. "


### PR DESCRIPTION
bootstrap-orbit-ggp.sh does not use packages installed via
apt-get install, therefore it needs llvm to be installed in
sysroot or as a vcpkg target. This change adds it to vcpkg
install list.

Test: run bootstrap-orbit-ggp.sh