### PR TITLE
Start enforcing -Werror=all on OrbitCore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ set(CMAKE_TOOLCHAIN_FILE
     "${CMAKE_CURRENT_LIST_DIR}/external/vcpkg/scripts/buildsystems/vcpkg.cmake"
     CACHE STRING "Default CMake toolchain file")
 
+if(NOT WIN32)
+  # These flags do not work on Windows.
+  set(STRICT_COMPILE_FLAGS -Werror=all)
+endif()
+
 project(Orbit C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 project(OrbitCore)
 add_library(OrbitCore STATIC)
 
+target_compile_options(OrbitCore PRIVATE ${STRICT_COMPILE_FLAGS})
+
 target_sources(
   OrbitCore
   PUBLIC BaseTypes.h

--- a/OrbitCore/ElfFile.h
+++ b/OrbitCore/ElfFile.h
@@ -12,6 +12,7 @@
 class ElfFile {
  public:
   ElfFile() = default;
+  virtual ~ElfFile() = default;
 
   virtual bool GetFunctions(Pdb* pdb,
                             std::vector<Function>* functions) const = 0;

--- a/OrbitCore/LinuxPerf.h
+++ b/OrbitCore/LinuxPerf.h
@@ -25,7 +25,6 @@ class LinuxPerf {
 
  private:
   uint32_t m_PID = 0;
-  uint32_t m_ForkedPID = 0;
   uint32_t m_Frequency = 1000;
 
   std::shared_ptr<std::thread> m_Thread;

--- a/OrbitCore/LinuxUtils.cpp
+++ b/OrbitCore/LinuxUtils.cpp
@@ -122,7 +122,6 @@ void ListModules(pid_t a_PID,
     std::vector<std::string> tokens = Tokenize(line);
     if (tokens.size() == 6) {
       const std::string& moduleName = tokens[5];
-      const std::string& permission = tokens[1];
 
       auto addresses = Tokenize(tokens[0], "-");
       if (addresses.size() == 2) {

--- a/OrbitCore/OrbitFunction.h
+++ b/OrbitCore/OrbitFunction.h
@@ -178,7 +178,6 @@ class Function {
   std::vector<FunctionParam> params_;
   std::vector<Argument> arguments_;
   Pdb* pdb_ = nullptr;
-  uint64_t name_hash_ = 0;
   OrbitType type_ = NONE;
   std::shared_ptr<FunctionStats> stats_;
   bool selected_ = false;

--- a/OrbitCore/Pdb.h
+++ b/OrbitCore/Pdb.h
@@ -28,7 +28,7 @@ class Pdb {
   explicit Pdb(const char* pdb_name = "");
   Pdb(const Pdb&) = delete;
   Pdb& operator=(const Pdb&) = delete;
-  ~Pdb();
+  virtual ~Pdb();
 
   void Init();
 
@@ -142,6 +142,7 @@ class Pdb {
   Pdb() = default;
   Pdb(const Pdb&) = delete;
   Pdb& operator=(const Pdb&) = delete;
+  virtual ~Pdb() = default;
 
   void Init() {}
 

--- a/OrbitCore/Systrace.h
+++ b/OrbitCore/Systrace.h
@@ -44,9 +44,6 @@ class Systrace {
   std::vector<Function> m_Functions;
   std::unordered_map<uint64_t, Function*> m_FunctionMap;
 
-  DWORD m_ThreadCount = 0;
-  DWORD m_StringCount = 0;
-
   std::string m_Name;
 
   uint64_t m_TimeOffsetNs = 0;
@@ -70,3 +67,4 @@ class SystraceManager {
   std::vector<std::shared_ptr<Systrace>> m_Systraces;
   uint32_t m_ThreadCount = 0;
 };
+

--- a/OrbitCore/TcpServer.h
+++ b/OrbitCore/TcpServer.h
@@ -15,6 +15,7 @@ class TcpServer : public TcpEntity {
   TcpServer();
   ~TcpServer();
 
+  using TcpEntity::Start;
   void Start(unsigned short a_Port);
 
   void Receive(const Message& a_Message);

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -4,6 +4,8 @@ project(OrbitLinuxTracing)
 
 add_library(OrbitLinuxTracing STATIC)
 
+target_compile_options(OrbitLinuxTracing PRIVATE ${STRICT_COMPILE_FLAGS})
+
 target_compile_features(OrbitLinuxTracing PUBLIC cxx_std_17)
 
 target_include_directories(OrbitLinuxTracing PUBLIC

--- a/OrbitLinuxTracing/Logging.h
+++ b/OrbitLinuxTracing/Logging.h
@@ -5,8 +5,13 @@
 
 #include <cstdio>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+
 #define LOG(format, ...) fprintf(stderr, format "\n", ##__VA_ARGS__)
 
 #define ERROR(format, ...) LOG("Error: " format, ##__VA_ARGS__)
+
+#pragma clang diagnostic pop
 
 #endif  // ORBIT_LINUX_TRACING_LOGGING_H_

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -23,6 +23,7 @@ class PerfEventVisitor;
 
 class PerfEvent {
  public:
+  virtual ~PerfEvent() = default;
   virtual uint64_t Timestamp() const = 0;
   virtual void accept(PerfEventVisitor* visitor) = 0;
 };

--- a/OrbitLinuxTracing/PerfEventVisitor.h
+++ b/OrbitLinuxTracing/PerfEventVisitor.h
@@ -8,6 +8,7 @@ namespace LinuxTracing {
 // Keep this class in sync with the hierarchy of PerfEvent in PerfEvent.h.
 class PerfEventVisitor {
  public:
+  virtual ~PerfEventVisitor() = default;
   virtual void visit(LostPerfEvent* event) {}
   virtual void visit(ForkPerfEvent* event) {}
   virtual void visit(ExitPerfEvent* event) {}

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/TracerListener.h
@@ -7,6 +7,7 @@ namespace LinuxTracing {
 
 class TracerListener {
  public:
+  virtual ~TracerListener() = default;
   virtual void OnTid(pid_t tid) = 0;
   virtual void OnContextSwitchIn(const ContextSwitchIn& context_switch_in) = 0;
   virtual void OnContextSwitchOut(


### PR DESCRIPTION
Starting effort of eliminating warnings from the Orbit code.

Test: cmake --build .