### PR TITLE
Disable clang diagnostics pragma on windows

### DIFF
--- a/OrbitLinuxTracing/Logging.h
+++ b/OrbitLinuxTracing/Logging.h
@@ -5,13 +5,17 @@
 
 #include <cstdio>
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#endif
 
 #define LOG(format, ...) fprintf(stderr, format "\n", ##__VA_ARGS__)
 
 #define ERROR(format, ...) LOG("Error: " format, ##__VA_ARGS__)
 
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 #endif  // ORBIT_LINUX_TRACING_LOGGING_H_


### PR DESCRIPTION
Use clang diagnostics pragma only if it project is compiled with clang.

Bug: http://b/150575491
Test: ninja