### PR TITLE
Removed vcpkg dependency from toolchain file templates.

### DIFF
--- a/contrib/toolchains/toolchain-linux-clang9-debug.cmake
+++ b/contrib/toolchains/toolchain-linux-clang9-debug.cmake
@@ -42,7 +42,3 @@ add_compile_options(
   -Wstack-protector
   -fcolor-diagnostics
   -fno-omit-frame-pointer)
-
-include(
-  "${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake"
-)

--- a/contrib/toolchains/toolchain-linux-clang9-release.cmake
+++ b/contrib/toolchains/toolchain-linux-clang9-release.cmake
@@ -43,7 +43,3 @@ add_compile_options(
   -Wdisabled-optimization
   -Wstack-protector
   -fcolor-diagnostics)
-
-include(
-  "${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake"
-)

--- a/contrib/toolchains/toolchain-linux-default-debug.cmake
+++ b/contrib/toolchains/toolchain-linux-default-debug.cmake
@@ -35,7 +35,3 @@ add_compile_options(
   -Wdisabled-optimization
   -Wstack-protector
   -fno-omit-frame-pointer)
-
-include(
-  "${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake"
-)

--- a/contrib/toolchains/toolchain-linux-default-release.cmake
+++ b/contrib/toolchains/toolchain-linux-default-release.cmake
@@ -7,7 +7,3 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 
 string(APPEND CMAKE_CXX_FLAGS " -march=skylake")
-
-include(
-  "${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake"
-)

--- a/contrib/toolchains/toolchain-linux-ggp-release.cmake
+++ b/contrib/toolchains/toolchain-linux-ggp-release.cmake
@@ -9,8 +9,3 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
 set(VCPKG_TARGET_TRIPLET
     "x64-linux-ggp"
     CACHE STRING "vcpkg's target triplet" FORCE)
-
-include($ENV{GGP_SDK_PATH}/cmake/ggp.cmake)
-
-include(
-  ${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake)

--- a/contrib/toolchains/toolchain-windows-32bit-msvc-debug.cmake
+++ b/contrib/toolchains/toolchain-windows-32bit-msvc-debug.cmake
@@ -15,7 +15,3 @@ string(APPEND CMAKE_CXX_FLAGS " /MP")
 
 add_link_options(/INCREMENTAL:NO)
 
-# This include expects your build directory to be a direct subdirectory of the
-# project root.
-include(
-  ${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake)

--- a/contrib/toolchains/toolchain-windows-32bit-msvc-release.cmake
+++ b/contrib/toolchains/toolchain-windows-32bit-msvc-release.cmake
@@ -10,7 +10,3 @@ string(APPEND CMAKE_CXX_FLAGS " /wd4481")
 string(APPEND CMAKE_CXX_FLAGS " /wd4201")
 string(APPEND CMAKE_CXX_FLAGS " /MP")
 
-# This include expects your build directory to be a direct subdirectory of the
-# project root.
-include(
-  ${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake)

--- a/contrib/toolchains/toolchain-windows-64bit-msvc-debug.cmake
+++ b/contrib/toolchains/toolchain-windows-64bit-msvc-debug.cmake
@@ -15,7 +15,3 @@ string(APPEND CMAKE_CXX_FLAGS " /MP")
 
 add_link_options(/INCREMENTAL:NO)
 
-# This include expects your build directory to be a direct subdirectory of the
-# project root.
-include(
-  ${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake)

--- a/contrib/toolchains/toolchain-windows-64bit-msvc-release.cmake
+++ b/contrib/toolchains/toolchain-windows-64bit-msvc-release.cmake
@@ -10,7 +10,3 @@ string(APPEND CMAKE_CXX_FLAGS " /wd4481")
 string(APPEND CMAKE_CXX_FLAGS " /wd4201")
 string(APPEND CMAKE_CXX_FLAGS " /MP")
 
-# This include expects your build directory to be a direct subdirectory of the
-# project root.
-include(
-  ${CMAKE_CURRENT_LIST_DIR}/../external/vcpkg/scripts/buildsystems/vcpkg.cmake)


### PR DESCRIPTION
The `include(.../vcpkg.cmake)` is not needed anymore, since vcpkg is no longer Orbit's package manager