### PR TITLE
Explicitly include Logging.h to Utils.h

### DIFF
--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <thread>
 
+#include "Logging.h"
 #include "absl/strings/str_format.h"
 
 namespace LinuxTracing {


### PR DESCRIPTION
Utils depend on Logging for ERROR macro.

Test: cmake --build .