### PR TITLE
Fix broken Windows built. 

### DIFF
--- a/OrbitCore/PrintVar.h
+++ b/OrbitCore/PrintVar.h
@@ -30,11 +30,19 @@
   abort(); \
 }
 
+#if __linux__
 #define CHECK(assertion) {\
   if (__builtin_expect(!(assertion), false)) {\
     FATAL(#assertion);\
   }\
 }
+#else
+#define CHECK(assertion) {\
+  if (!(assertion)) {\
+    FATAL(#assertion);\
+  }\
+}
+#endif
 
 //-----------------------------------------------------------------------------
 inline void PrintVar(const char* a_VarName, const std::wstring& a_Value,


### PR DESCRIPTION
__builtin_expect is not available for the MS compiler so we just skip this optimization.