### PR TITLE
Remove packaging step from build.{sh,bat}

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -39,9 +39,6 @@ for /L %%i in (1,1,%argCount%) do (
 
     call conan build -bf build_!profile!/ !REPO_ROOT!
     if !errorlevel! neq 0 exit /b !errorlevel!
-
-    call conan package -bf build_!profile!/ !REPO_ROOT!
-    if !errorlevel! neq 0 exit /b !errorlevel!
 )
 
 EXIT /B 0

--- a/build.sh
+++ b/build.sh
@@ -40,5 +40,4 @@ for profile in ${profiles[@]}; do
 
   conan install -u -pr $profile -if build_$profile/ --build outdated $DIR || exit $?
   conan build -bf build_$profile/ $DIR || exit $?
-  conan package -bf build_$profile/ $DIR || exit $?
 done


### PR DESCRIPTION
The packaging step which is automatically performed in the `build.{sh.bat}` script lead to some confusion.

And since there is no reason to perform this step on every build, this PR suggests to remove it entirely.

As soon as we look into packaging this will come back, but probably in a different (packaging-) script.