### PR TITLE
Move server-side logic out of OrbitGl module

### DIFF
--- a/OrbitCore/Capture.cpp
+++ b/OrbitCore/Capture.cpp
@@ -331,10 +331,10 @@ void Capture::SendFunctionHooks() {
                      (void*)selectedFunctionsData.data(),
                      selectedFunctionsData.size());
 
-    GTcpClient->Send(Msg_StartCapture);
-  } else
-    // TODO: Why is this? This seems to be unnecessary.
-    GTcpServer->Send(Msg_StartCapture);
+    Message msg(Msg_StartCapture);
+    msg.m_Header.m_GenericHeader.m_Address = GTargetProcess->GetID();
+    GTcpClient->Send(msg);
+  }
 
   // Unreal
   if (Capture::GUnrealSupported) {

--- a/OrbitCore/Capture.h
+++ b/OrbitCore/Capture.h
@@ -54,6 +54,16 @@ struct Capture {
   static void SetLoadPdbAsyncFunc(LoadPdbAsyncFunc a_Func) {
     GLoadPdbAsync = a_Func;
   }
+
+  typedef void (*SamplingDoneCallback)(
+      std::shared_ptr<SamplingProfiler>& sampling_profiler,
+      void* user_data);
+  static void SetSamplingDoneCallback(SamplingDoneCallback callback,
+                                      void* user_data) {
+    sampling_done_callback_ = callback;
+    sampling_done_callback_user_data_ = user_data;
+  }
+
   static void TestRemoteMessages();
   static class TcpEntity* GetMainTcpEntity();
 
@@ -83,8 +93,6 @@ struct Capture {
   static std::shared_ptr<Session> GSessionPresets;
   static std::shared_ptr<CallStack> GSelectedCallstack;
   static void (*GClearCaptureDataFunc)();
-  static void (*GSamplingDoneCallback)(
-      std::shared_ptr<SamplingProfiler>& a_SamplingProfiler);
   static std::map<ULONG64, Function*> GSelectedFunctionsMap;
   static std::map<ULONG64, Function*> GVisibleFunctionsMap;
   static std::unordered_map<ULONG64, ULONG64> GFunctionCountMap;
@@ -98,4 +106,7 @@ struct Capture {
   static Mutex GCallstackMutex;
   static LoadPdbAsyncFunc GLoadPdbAsync;
   static bool GUnrealSupported;
+ private:
+  static SamplingDoneCallback sampling_done_callback_;
+  static void* sampling_done_callback_user_data_;
 };

--- a/OrbitCore/ConnectionManager.h
+++ b/OrbitCore/ConnectionManager.h
@@ -10,6 +10,8 @@
 #include <vector>
 
 #include "Message.h"
+#include "ProcessUtils.h"
+#include "TcpEntity.h"
 
 class ConnectionManager {
  public:
@@ -20,20 +22,21 @@ class ConnectionManager {
   void InitAsService();
   void ConnectToRemote(std::string a_RemoteAddress);
   void SetSelectedFunctionsOnRemote(const Message& a_Msg);
-  bool IsService() { return m_IsService; }
-  void StartCaptureAsRemote();
+  bool IsService() const { return m_IsService; }
+  void StartCaptureAsRemote(uint32_t pid);
   void StopCaptureAsRemote();
   void Stop();
 
- protected:
+ private:
   void ConnectionThread();
   void RemoteThread();
   void TerminateThread();
   void SetupClientCallbacks();
   void SetupServerCallbacks();
-  void SendProcesses(class TcpEntity* a_TcpEntity);
+  void SendProcesses(TcpEntity* tcp_entry);
+  void SendRemoteProcess(TcpEntity* tcp_entry, uint32_t pid);
 
- protected:
+  ProcessList process_list_;
   std::unique_ptr<std::thread> m_Thread;
   std::string m_RemoteAddress;
   std::atomic<bool> m_ExitRequested;

--- a/OrbitCore/CoreApp.h
+++ b/OrbitCore/CoreApp.h
@@ -48,7 +48,6 @@ class CoreApp {
   GetRules() {
     return nullptr;
   }
-  virtual void SendRemoteProcess(uint32_t /*a_PID*/) {}
   virtual void RefreshCaptureView() {}
 
   virtual void StartRemoteCaptureBufferingThread() {}

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -414,7 +414,7 @@ bool OrbitApp::Init() {
 
   GModuleManager.Init();
   Capture::Init();
-  Capture::GSamplingDoneCallback = &OrbitApp::AddSamplingReport;
+  Capture::SetSamplingDoneCallback(&OrbitApp::AddSamplingReport, GOrbitApp);
   Capture::SetLoadPdbAsyncFunc(GLoadPdbAsync);
 
 #ifdef _WIN32
@@ -819,11 +819,11 @@ void OrbitApp::NeedsRedraw() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::AddSamplingReport(
-    std::shared_ptr<SamplingProfiler>& a_SamplingProfiler) {
-  auto report = std::make_shared<SamplingReport>(a_SamplingProfiler);
+    std::shared_ptr<SamplingProfiler>& sampling_profiler, void* app_ptr) {
+  OrbitApp* app = static_cast<OrbitApp*>(app_ptr);
+  auto report = std::make_shared<SamplingReport>(sampling_profiler);
 
-  for (SamplingReportCallback& callback :
-       GOrbitApp->m_SamplingReportsCallbacks) {
+  for (SamplingReportCallback& callback : app->m_SamplingReportsCallbacks) {
     callback(report);
   }
 }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -583,17 +583,6 @@ void OrbitApp::SetRemoteProcess(std::shared_ptr<Process> a_Process) {
 }
 
 //-----------------------------------------------------------------------------
-void OrbitApp::SendRemoteProcess(uint32_t a_PID) {
-  std::shared_ptr<Process> process = m_ProcessesDataView->SelectProcess(a_PID);
-
-  if (process) {
-    std::string processData = SerializeObjectHumanReadable(*process);
-    GTcpServer->Send(Msg_RemoteProcess, (void*)processData.data(),
-                     processData.size());
-  }
-}
-
-//-----------------------------------------------------------------------------
 void OrbitApp::RefreshCaptureView() {
   NeedsRedraw();
   GOrbitApp->FireRefreshCallbacks();
@@ -1167,9 +1156,12 @@ void OrbitApp::LoadRemoteModules() {
     }
   }
 
-  std::string moduleData = SerializeObjectBinary(modules);
-  GTcpClient->Send(Msg_RemoteModuleDebugInfo, (void*)moduleData.data(),
-                   moduleData.size());
+  std::string module_data = SerializeObjectBinary(modules);
+  Message msg(Msg_RemoteModuleDebugInfo, module_data.size() + 1,
+              module_data.data());
+  msg.m_Header.m_GenericHeader.m_Address =
+      m_ProcessesDataView->GetSelectedProcess()->GetID();
+  GTcpClient->Send(msg);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -100,9 +100,12 @@ class OrbitApp : public CoreApp {
   bool SelectProcess(uint32_t a_ProcessID);
   bool Inject(unsigned long a_ProcessId);
   static void AddSamplingReport(
-      std::shared_ptr<class SamplingProfiler>& a_SamplingProfiler);
+      std::shared_ptr<class SamplingProfiler>& sampling_profiler,
+      void* app_ptr);
+
   static void AddSelectionReport(
       std::shared_ptr<SamplingProfiler>& a_SamplingProfiler);
+
   void GoToCode(DWORD64 a_Address);
   void GoToCallstack();
   void GoToCapture();

--- a/OrbitGl/App.h
+++ b/OrbitGl/App.h
@@ -9,10 +9,11 @@
 #include <queue>
 #include <string>
 
-#include "../OrbitCore/ContextSwitch.h"
-#include "../OrbitCore/CoreApp.h"
-#include "../OrbitCore/CrashHandler.h"
-#include "../OrbitCore/Message.h"
+#include "ContextSwitch.h"
+#include "CoreApp.h"
+#include "CrashHandler.h"
+#include "Message.h"
+
 #include "DataViewTypes.h"
 #include "Threading.h"
 
@@ -62,7 +63,6 @@ class OrbitApp : public CoreApp {
   void AppendSystrace(const std::string& a_FileName, uint64_t a_TimeOffset);
   void ListSessions();
   void SetRemoteProcess(std::shared_ptr<Process> a_Process);
-  void SendRemoteProcess(uint32_t a_PID) override;
   void RefreshCaptureView() override;
   void RequestRemoteModules(const std::vector<std::string> a_Modules);
   void AddWatchedVariable(Variable* a_Variable);

--- a/OrbitGl/ProcessDataView.h
+++ b/OrbitGl/ProcessDataView.h
@@ -32,6 +32,10 @@ class ProcessesDataView : public DataView {
   void UpdateModuleDataView(std::shared_ptr<Process> a_Process);
   void SetIsRemote(bool a_Value) { m_IsRemote = true; }
 
+  std::shared_ptr<Process> GetSelectedProcess() const {
+    return m_SelectedProcess;
+  }
+
   // void SetSelectedProcessCtrl(SelectedProcessPanel* a_Panel ) {
   // m_SelectedProcessPanel = a_Panel; }
 


### PR DESCRIPTION
This PR prepares everything for OrbitService to stop relying on OrbitGl module. ProcessList is now managed by ConnectionManager class instead of App.