### PR TITLE
Added OrbitLinuxTracingTests to ctest.

### DIFF
--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -59,3 +59,5 @@ target_link_libraries(OrbitLinuxTracingTests PRIVATE
         OrbitLinuxTracing
         GTest::GTest
         GTest::Main)
+
+add_test(NAME OrbitLinuxTracing COMMAND OrbitLinuxTracingTests)


### PR DESCRIPTION
This change makes the tests of the OrbitLinuxTracing module run on the CI or locally if you just call `ctest` in your build directory.