### PR TITLE
Allocate and copy only actual stack from ring buffer

### DIFF
--- a/OrbitCore/LinuxTracingHandler.h
+++ b/OrbitCore/LinuxTracingHandler.h
@@ -11,7 +11,7 @@
 
 class LinuxTracingHandler : LinuxTracing::TracerListener {
  public:
-  static constexpr double DEFAULT_SAMPLING_FREQUENCY = 99.0;
+  static constexpr double DEFAULT_SAMPLING_FREQUENCY = 1000.0;
 
   LinuxTracingHandler(CoreApp* core_app, Process* target_process,
                       std::map<ULONG64, Function*>* selected_function_map,

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(OrbitLinuxTracing PUBLIC
 target_sources(OrbitLinuxTracing PRIVATE
         LibunwindstackUnwinder.cpp
         LibunwindstackUnwinder.h
+        MakeUniqueForOverwrite.h
         Logging.h
         PerfEvent.cpp
         PerfEvent.h

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(OrbitLinuxTracing PRIVATE
         PerfEventProcessor.h
         PerfEventProcessor2.cpp
         PerfEventProcessor2.h
+        PerfEventReaders.h
         PerfEventRecords.h
         PerfEventRingBuffer.cpp
         PerfEventRingBuffer.h

--- a/OrbitLinuxTracing/MakeUniqueForOverwrite.h
+++ b/OrbitLinuxTracing/MakeUniqueForOverwrite.h
@@ -1,0 +1,20 @@
+#ifndef ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_
+#define ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_
+
+#include <memory>
+
+// Unlike std::make_unique, calls new without parentheses, causing the object
+// to be default-initialized instead of value-initialized.
+// This can prevent useless memory initialization.
+// Standard version coming in C++20.
+template <class T>
+inline std::unique_ptr<T> make_unique_for_overwrite() {
+  return std::unique_ptr<T>(new T);
+}
+
+template <class T>
+inline std::unique_ptr<T> make_unique_for_overwrite(size_t size) {
+  return std::unique_ptr<T>(new typename std::remove_extent<T>::type[size]);
+}
+
+#endif  // ORBIT_LINUX_TRACING_MAKE_UNIQUE_FOR_OVERWRITE_H_

--- a/OrbitLinuxTracing/PerfEvent.h
+++ b/OrbitLinuxTracing/PerfEvent.h
@@ -131,10 +131,9 @@ class LostPerfEvent : public PerfEvent {
   uint64_t GetNumLost() const { return ring_buffer_record.lost; }
 };
 
-template <typename perf_record_t>
 class SamplePerfEvent : public PerfEvent {
  public:
-  perf_record_t ring_buffer_record;
+  perf_event_stack_sample ring_buffer_record;
 
   uint64_t GetTimestamp() const override {
     return ring_buffer_record.sample_id.time;
@@ -143,56 +142,55 @@ class SamplePerfEvent : public PerfEvent {
   pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
   pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
   uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
-};
-
-namespace {
-std::array<uint64_t, PERF_REG_X86_64_MAX>
-perf_sample_regs_user_all_to_register_array(
-    const perf_event_sample_regs_user_all& regs) {
-  std::array<uint64_t, PERF_REG_X86_64_MAX> registers{};
-  registers[PERF_REG_X86_AX] = regs.ax;
-  registers[PERF_REG_X86_BX] = regs.bx;
-  registers[PERF_REG_X86_CX] = regs.cx;
-  registers[PERF_REG_X86_DX] = regs.dx;
-  registers[PERF_REG_X86_SI] = regs.si;
-  registers[PERF_REG_X86_DI] = regs.di;
-  registers[PERF_REG_X86_BP] = regs.bp;
-  registers[PERF_REG_X86_SP] = regs.sp;
-  registers[PERF_REG_X86_IP] = regs.ip;
-  registers[PERF_REG_X86_FLAGS] = regs.flags;
-  registers[PERF_REG_X86_CS] = regs.cs;
-  registers[PERF_REG_X86_SS] = regs.ss;
-  // Registers ds, es, fs, gs do not actually exist.
-  registers[PERF_REG_X86_DS] = 0ul;
-  registers[PERF_REG_X86_ES] = 0ul;
-  registers[PERF_REG_X86_FS] = 0ul;
-  registers[PERF_REG_X86_GS] = 0ul;
-  registers[PERF_REG_X86_R8] = regs.r8;
-  registers[PERF_REG_X86_R9] = regs.r9;
-  registers[PERF_REG_X86_R10] = regs.r10;
-  registers[PERF_REG_X86_R11] = regs.r11;
-  registers[PERF_REG_X86_R12] = regs.r12;
-  registers[PERF_REG_X86_R13] = regs.r13;
-  registers[PERF_REG_X86_R14] = regs.r14;
-  registers[PERF_REG_X86_R15] = regs.r15;
-  return registers;
-}
-}  // namespace
-
-class StackSamplePerfEvent : public SamplePerfEvent<perf_event_stack_sample> {
- public:
-  void Accept(PerfEventVisitor* visitor) override;
 
   std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
-    return perf_sample_regs_user_all_to_register_array(ring_buffer_record.regs);
+    return perf_event_sample_regs_user_all_to_register_array(
+        ring_buffer_record.regs);
   }
 
   const char* GetStackData() const { return ring_buffer_record.stack.data; }
   uint64_t GetStackSize() const { return ring_buffer_record.stack.dyn_size; }
+
+ private:
+  static std::array<uint64_t, PERF_REG_X86_64_MAX>
+  perf_event_sample_regs_user_all_to_register_array(
+      const perf_event_sample_regs_user_all& regs) {
+    std::array<uint64_t, PERF_REG_X86_64_MAX> registers{};
+    registers[PERF_REG_X86_AX] = regs.ax;
+    registers[PERF_REG_X86_BX] = regs.bx;
+    registers[PERF_REG_X86_CX] = regs.cx;
+    registers[PERF_REG_X86_DX] = regs.dx;
+    registers[PERF_REG_X86_SI] = regs.si;
+    registers[PERF_REG_X86_DI] = regs.di;
+    registers[PERF_REG_X86_BP] = regs.bp;
+    registers[PERF_REG_X86_SP] = regs.sp;
+    registers[PERF_REG_X86_IP] = regs.ip;
+    registers[PERF_REG_X86_FLAGS] = regs.flags;
+    registers[PERF_REG_X86_CS] = regs.cs;
+    registers[PERF_REG_X86_SS] = regs.ss;
+    // Registers ds, es, fs, gs do not actually exist.
+    registers[PERF_REG_X86_DS] = 0ul;
+    registers[PERF_REG_X86_ES] = 0ul;
+    registers[PERF_REG_X86_FS] = 0ul;
+    registers[PERF_REG_X86_GS] = 0ul;
+    registers[PERF_REG_X86_R8] = regs.r8;
+    registers[PERF_REG_X86_R9] = regs.r9;
+    registers[PERF_REG_X86_R10] = regs.r10;
+    registers[PERF_REG_X86_R11] = regs.r11;
+    registers[PERF_REG_X86_R12] = regs.r12;
+    registers[PERF_REG_X86_R13] = regs.r13;
+    registers[PERF_REG_X86_R14] = regs.r14;
+    registers[PERF_REG_X86_R15] = regs.r15;
+    return registers;
+  }
 };
 
-template <typename perf_record_t>
-class AbstractUprobesPerfEvent : public SamplePerfEvent<perf_record_t> {
+class StackSamplePerfEvent : public SamplePerfEvent {
+ public:
+  void Accept(PerfEventVisitor* visitor) override;
+};
+
+class AbstractUprobesPerfEvent {
  public:
   const Function* GetFunction() const { return function_; }
   void SetFunction(const Function* function) { function_ = function; }
@@ -201,23 +199,25 @@ class AbstractUprobesPerfEvent : public SamplePerfEvent<perf_record_t> {
   const Function* function_ = nullptr;
 };
 
-class UprobesWithStackPerfEvent
-    : public AbstractUprobesPerfEvent<perf_event_stack_sample> {
+class UprobesWithStackPerfEvent : public SamplePerfEvent,
+                                  public AbstractUprobesPerfEvent {
  public:
   void Accept(PerfEventVisitor* visitor) override;
-
-  std::array<uint64_t, PERF_REG_X86_64_MAX> GetRegisters() const {
-    return perf_sample_regs_user_all_to_register_array(ring_buffer_record.regs);
-  }
-
-  const char* GetStackData() const { return ring_buffer_record.stack.data; }
-  uint64_t GetStackSize() const { return ring_buffer_record.stack.dyn_size; }
 };
 
-class UretprobesPerfEvent
-    : public AbstractUprobesPerfEvent<perf_event_empty_sample> {
+class UretprobesPerfEvent : public PerfEvent, public AbstractUprobesPerfEvent {
  public:
+  perf_event_empty_sample ring_buffer_record;
+
+  uint64_t GetTimestamp() const override {
+    return ring_buffer_record.sample_id.time;
+  }
+
   void Accept(PerfEventVisitor* visitor) override;
+
+  pid_t GetPid() const { return ring_buffer_record.sample_id.pid; }
+  pid_t GetTid() const { return ring_buffer_record.sample_id.tid; }
+  uint32_t GetCpu() const { return ring_buffer_record.sample_id.cpu; }
 };
 
 // This carries a snapshot of /proc/<pid>/maps and does not reflect a

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -1,5 +1,5 @@
-#ifndef ORBIT_LINUX_TRACING_LINUX_PERF_UTILS_H_
-#define ORBIT_LINUX_TRACING_LINUX_PERF_UTILS_H_
+#ifndef ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_
+#define ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_
 
 #include <asm/perf_regs.h>
 #include <asm/unistd.h>
@@ -91,4 +91,4 @@ void* perf_event_open_mmap_ring_buffer(int fd, uint64_t mmap_length);
 
 }  // namespace LinuxTracing
 
-#endif  // ORBIT_LINUX_TRACING_LINUX_PERF_UTILS_H_
+#endif  // ORBIT_LINUX_TRACING_PERF_EVENT_OPEN_H_

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -23,11 +23,17 @@ inline int perf_event_open(struct perf_event_attr* attr, pid_t pid, int cpu,
 namespace LinuxTracing {
 
 inline void perf_event_reset(int file_descriptor) {
-  ioctl(file_descriptor, PERF_EVENT_IOC_RESET, 0);
+  int ret = ioctl(file_descriptor, PERF_EVENT_IOC_RESET, 0);
+  if (ret != 0) {
+    ERROR("PERF_EVENT_IOC_RESET: %d", ret);
+  }
 }
 
 inline void perf_event_enable(int file_descriptor) {
-  ioctl(file_descriptor, PERF_EVENT_IOC_ENABLE, 0);
+  int ret = ioctl(file_descriptor, PERF_EVENT_IOC_ENABLE, 0);
+  if (ret != 0) {
+    ERROR("PERF_EVENT_IOC_ENABLE: %d", ret);
+  }
 }
 
 inline void perf_event_reset_and_enable(int file_descriptor) {
@@ -36,7 +42,17 @@ inline void perf_event_reset_and_enable(int file_descriptor) {
 }
 
 inline void perf_event_disable(int file_descriptor) {
-  ioctl(file_descriptor, PERF_EVENT_IOC_DISABLE, 0);
+  int ret = ioctl(file_descriptor, PERF_EVENT_IOC_DISABLE, 0);
+  if (ret != 0) {
+    ERROR("PERF_EVENT_IOC_DISABLE: %d", ret);
+  }
+}
+
+inline void perf_event_redirect(int from_fd, int to_fd) {
+  int ret = ioctl(from_fd, PERF_EVENT_IOC_SET_OUTPUT, to_fd);
+  if (ret != 0) {
+    ERROR("PERF_EVENT_IOC_SET_OUTPUT: %d\n", ret);
+  }
 }
 
 // This must be in sync with struct perf_event_sample_id_tid_time_cpu in

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -1,0 +1,35 @@
+#ifndef ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
+#define ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_
+
+#include "PerfEvent.h"
+#include "PerfEventRingBuffer.h"
+
+namespace LinuxTracing {
+
+// Helper functions for reads from a perf_event_open ring buffer that require
+// more complex operations than simply copying an entire perf_event_open record.
+
+template<typename SamplePerfEventT>
+inline std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(
+    PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
+  // Data in the ring buffer has the layout of perf_event_stack_sample, but we
+  // copy it into dynamically_sized_perf_event_stack_sample.
+  uint64_t dyn_size;
+  ring_buffer->ReadValueAtOffset(
+      &dyn_size, offsetof(perf_event_stack_sample, stack.dyn_size));
+  auto event = std::make_unique<SamplePerfEventT>(dyn_size);
+  event->ring_buffer_record.header = header;
+  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record.sample_id,
+                                 offsetof(perf_event_stack_sample, sample_id));
+  ring_buffer->ReadValueAtOffset(&event->ring_buffer_record.regs,
+                                 offsetof(perf_event_stack_sample, regs));
+  ring_buffer->ReadRawAtOffset(event->ring_buffer_record.stack.data.get(),
+                               offsetof(perf_event_stack_sample, stack.data),
+                               dyn_size);
+  ring_buffer->SkipRecord(header);
+  return event;
+}
+
+}
+
+#endif  // ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_

--- a/OrbitLinuxTracing/PerfEventRingBuffer.cpp
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.cpp
@@ -85,32 +85,27 @@ bool PerfEventRingBuffer::HasNewData() {
 }
 
 void PerfEventRingBuffer::ReadHeader(perf_event_header* header) {
-  assert(IsOpen());
   ReadAtTail(reinterpret_cast<uint8_t*>(header), sizeof(perf_event_header));
   assert(header->type != 0);
   assert(metadata_page_->data_tail + header->size <= metadata_page_->data_head);
 }
 
 void PerfEventRingBuffer::SkipRecord(const perf_event_header& header) {
-  assert(IsOpen());
   // Write back how far we read from the buffer.
   metadata_page_->data_tail += header.size;
 }
 
 void PerfEventRingBuffer::ConsumeRecord(const perf_event_header& header,
                                         void* record) {
-  assert(IsOpen());
   ReadAtTail(static_cast<uint8_t*>(record), header.size);
   SkipRecord(header);
-}
-
-void PerfEventRingBuffer::ReadAtTail(uint8_t* dest, uint64_t count) {
-  return ReadAtOffsetFromTail(dest, 0, count);
 }
 
 void PerfEventRingBuffer::ReadAtOffsetFromTail(uint8_t* dest,
                                                uint64_t offset_from_tail,
                                                uint64_t count) {
+  assert(IsOpen());
+
   if (offset_from_tail + count >
       metadata_page_->data_head - metadata_page_->data_tail) {
     ERROR("Reading more data than it is available from the ring buffer");

--- a/OrbitLinuxTracing/PerfEventRingBuffer.h
+++ b/OrbitLinuxTracing/PerfEventRingBuffer.h
@@ -28,6 +28,19 @@ class PerfEventRingBuffer {
   void SkipRecord(const perf_event_header& header);
   void ConsumeRecord(const perf_event_header& header, void* record);
 
+  template <typename T>
+  void ReadValueAtOffset(T* value, uint64_t offset) {
+    ReadAtOffsetFromTail(reinterpret_cast<uint8_t*>(value), offset, sizeof(T));
+  }
+
+  void ReadRawAtOffset(uint8_t* dest, uint64_t offset, uint64_t count) {
+    ReadAtOffsetFromTail(dest, offset, count);
+  }
+
+  void ReadRawAtOffset(char* dest, uint64_t offset, uint64_t count) {
+    ReadAtOffsetFromTail(reinterpret_cast<uint8_t*>(dest), offset, count);
+  }
+
  private:
   uint64_t mmap_length_ = 0;
   perf_event_mmap_page* metadata_page_ = nullptr;
@@ -38,7 +51,10 @@ class PerfEventRingBuffer {
   uint32_t ring_buffer_size_log2_ = 0;
   int file_descriptor_ = -1;
 
-  void ReadAtTail(uint8_t* dest, uint64_t count);
+  void ReadAtTail(uint8_t* dest, uint64_t count) {
+    return ReadAtOffsetFromTail(dest, 0, count);
+  }
+
   void ReadAtOffsetFromTail(uint8_t* dest, uint64_t offset_from_tail,
                             uint64_t count);
 };

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -113,7 +113,6 @@ void TracerThread::Run(
     }
 
     last_iteration_saw_events = false;
-    new_threads_.clear();
     fds_to_remove_.clear();
 
     // Read and process events from all ring buffers. In order to ensure that no
@@ -301,7 +300,7 @@ void TracerThread::ProcessSampleEvent(const perf_event_header& header,
                                       PerfEventRingBuffer* ring_buffer) {
   int fd = ring_buffer->GetFileDescriptor();
   bool is_probe = uprobe_fds_to_function_.count(fd) > 0;
-  constexpr uint32_t size_of_uretprobe = sizeof(perf_event_empty_sample);
+  constexpr size_t size_of_uretprobe = sizeof(perf_event_empty_sample);
   bool is_uretprobe = is_probe && (header.size == size_of_uretprobe);
   bool is_uprobe = is_probe && !is_uretprobe;
 
@@ -376,7 +375,6 @@ void TracerThread::Reset() {
   threads_to_fd_.clear();
   uprobe_fds_to_function_.clear();
   fds_to_remove_.clear();
-  new_threads_.clear();
   deferred_events_.clear();
   stop_deferred_thread_ = false;
 }

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -9,7 +9,7 @@ namespace LinuxTracing {
 void TracerThread::Run(
     const std::shared_ptr<std::atomic<bool>>& exit_requested) {
   if (listener_ == nullptr) {
-    ERROR("No listener set to TracerThread, aborting trace.");
+    ERROR("No listener set to TracerThread, aborting trace");
     return;
   }
 
@@ -57,14 +57,8 @@ void TracerThread::Run(
 
         // Redirect uretprobes to uprobe ring buffer to reduce number of ring
         // buffers and to coalesce closely related events.
-        int ret = ioctl(uretprobe_fd, PERF_EVENT_IOC_SET_OUTPUT, uprobe_fd);
-        if (ret != 0) {
-          ERROR("PERF_EVENT_IOC_SET_OUTPUT error: %i.\n", ret);
-        }
-        ret = ioctl(uretprobe_fd, PERF_EVENT_IOC_ENABLE);
-        if (ret != 0) {
-          ERROR("PERF_EVENT_IOC_ENABLE error: %i.\n", ret);
-        }
+        perf_event_redirect(uretprobe_fd, uprobe_fd);
+        perf_event_enable(uretprobe_fd);
 
         // Track uretprobe fds separately as they map to a uprobe ring buffer.
         uret_probes_fds_.push_back(uretprobe_fd);

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -32,8 +32,8 @@ class TracerThread {
 
   TracerThread(const TracerThread&) = delete;
   TracerThread& operator=(const TracerThread&) = delete;
-  TracerThread(TracerThread&&) = default;
-  TracerThread& operator=(TracerThread&&) = default;
+  TracerThread(TracerThread&&) = delete;
+  TracerThread& operator=(TracerThread&&) = delete;
 
   void SetListener(TracerListener* listener) { listener_ = listener; }
 
@@ -98,7 +98,6 @@ class TracerThread {
   absl::flat_hash_map<int, const Function*> uprobe_fds_to_function_;
   std::vector<int> fds_to_remove_;
   std::vector<int> uret_probes_fds_;
-  std::vector<pid_t> new_threads_;
 
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -93,11 +93,11 @@ class TracerThread {
   bool trace_instrumented_functions_ = true;
 
   absl::flat_hash_map<int, PerfEventRingBuffer> fds_to_ring_buffer_;
-  std::vector<std::pair<int, PerfEventRingBuffer>> fds_to_ring_buffer_to_add_;
   absl::flat_hash_map<pid_t, int> threads_to_fd_;
-  absl::flat_hash_map<int, const Function*> uprobe_fds_to_function_;
+  absl::flat_hash_map<int, const Function*> uprobes_fds_to_function_;
+  std::vector<std::pair<int, PerfEventRingBuffer>> fds_to_ring_buffer_to_add_;
   std::vector<int> fds_to_remove_;
-  std::vector<int> uret_probes_fds_;
+  std::vector<int> uretprobes_fds_;
 
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -114,6 +114,28 @@ class TracerThread {
   };
 
   EventStats stats_;
+
+  template <typename SamplePerfEventT>
+  static std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(
+      PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
+    // Data in the ring buffer has the layout of perf_event_stack_sample, but we
+    // copy it into dynamically_sized_perf_event_stack_sample.
+    uint64_t dyn_size;
+    ring_buffer->ReadValueAtOffset(
+        &dyn_size, offsetof(perf_event_stack_sample, stack.dyn_size));
+    auto event = std::make_unique<SamplePerfEventT>(dyn_size);
+    event->ring_buffer_record.header = header;
+    ring_buffer->ReadValueAtOffset(
+        &event->ring_buffer_record.sample_id,
+        offsetof(perf_event_stack_sample, sample_id));
+    ring_buffer->ReadValueAtOffset(&event->ring_buffer_record.regs,
+                                   offsetof(perf_event_stack_sample, regs));
+    ring_buffer->ReadRawAtOffset(event->ring_buffer_record.stack.data.get(),
+                                 offsetof(perf_event_stack_sample, stack.data),
+                                 dyn_size);
+    ring_buffer->SkipRecord(header);
+    return event;
+  }
 };
 
 }  // namespace LinuxTracing


### PR DESCRIPTION
This concludes the optimizations related to copying stack data from the ring buffers.
It also performs other small fixes.
See the single commit messages for more details.