### PR TITLE
Enabled xUnit-XML-generation for ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 project(Orbit C CXX)
+
+include(cmake/tests.cmake)
 enable_testing()
 
 option(WITH_GUI "Setting this option will enable the Qt-based UI client." ON)

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -222,4 +222,4 @@ add_custom_command(TARGET OrbitCoreTests POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/testdata
   $<TARGET_FILE_DIR:OrbitCoreTests>/testdata)
 
-add_test(NAME OrbitCore COMMAND OrbitCoreTests)
+register_test(OrbitCoreTests)

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -60,4 +60,4 @@ target_link_libraries(OrbitLinuxTracingTests PRIVATE
         GTest::GTest
         GTest::Main)
 
-add_test(NAME OrbitLinuxTracing COMMAND OrbitLinuxTracingTests)
+register_test(OrbitLinuxTracingTests)

--- a/cmake/tests.cmake
+++ b/cmake/tests.cmake
@@ -1,0 +1,10 @@
+function(register_test)
+  set(TEST_TARGET "${ARGV0}")
+  string(REGEX REPLACE "Tests$" "" TEST_NAME "${TEST_TARGET}")
+
+  set(TESTRESULTS_DIRECTORY "${CMAKE_BINARY_DIR}/testresults")
+  add_test(NAME "${TEST_NAME}"
+          COMMAND "$<TARGET_FILE:${TEST_TARGET}>"
+          "--gtest_output=xml:${TESTRESULTS_DIRECTORY}/${TEST_NAME}.xml")
+endfunction()
+


### PR DESCRIPTION
This PR adds xUnit report generation to the gtest-based test executable.

A cmake function helps with configuring all test targets such that all
XML output files are put into one sub-directory called "testresults/".

Next step would be to make kokoro/sponge pick these reports up.
In case a change to the repo is needed, we should put this into this PR.