### PR TITLE
Sample based on cores

### DIFF
--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -42,6 +42,7 @@ void LinuxTracingHandler::Stop() {
 }
 
 void LinuxTracingHandler::OnTid(pid_t tid) {
+  // This doesn't seem to be of any use at the moment.
   target_process_->AddThreadId(tid);
 }
 

--- a/OrbitCore/LinuxTracingHandler.cpp
+++ b/OrbitCore/LinuxTracingHandler.cpp
@@ -42,7 +42,10 @@ void LinuxTracingHandler::Stop() {
 }
 
 void LinuxTracingHandler::OnTid(pid_t tid) {
-  // This doesn't seem to be of any use at the moment.
+  // TODO: This doesn't seem to be of any use at the moment: it has the effect
+  //  of adding the tid to Process::m_ThreadIds in OrbitProcess.h, but that
+  //  field is never actually used. Investigate whether m_ThreadIds should be
+  //  used or if this call should be removed.
   target_process_->AddThreadId(tid);
 }
 

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -43,7 +43,8 @@ target_sources(OrbitLinuxTracing PRIVATE
         TracerThread.h
         UprobesUnwindingVisitor.cpp
         UprobesUnwindingVisitor.h
-        Utils.h)
+        Utils.h
+        Utils.cpp)
 
 target_link_libraries(OrbitLinuxTracing PUBLIC
         abseil::abseil

--- a/OrbitLinuxTracing/PerfEventOpen.cpp
+++ b/OrbitLinuxTracing/PerfEventOpen.cpp
@@ -60,16 +60,22 @@ int context_switch_event_open(pid_t pid, int32_t cpu) {
   return generic_event_open(&pe, pid, cpu);
 }
 
-int sample_mmap_task_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
+int mmap_task_event_open(pid_t pid, int32_t cpu) {
+  perf_event_attr pe = generic_event_attr();
+  pe.type = PERF_TYPE_SOFTWARE;
+  pe.config = PERF_COUNT_SW_DUMMY;
+  pe.mmap = 1;
+  pe.task = 1;
+
+  return generic_event_open(&pe, pid, cpu);
+}
+
+int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu) {
   perf_event_attr pe = generic_event_attr();
   pe.type = PERF_TYPE_SOFTWARE;
   pe.config = PERF_COUNT_SW_CPU_CLOCK;
   pe.sample_period = period_ns;
   pe.sample_type |= PERF_SAMPLE_STACK_USER | PERF_SAMPLE_REGS_USER;
-  // Also record mmaps, ...
-  pe.mmap = 1;
-  // ... forks, and termination.
-  pe.task = 1;
 
   return generic_event_open(&pe, pid, cpu);
 }

--- a/OrbitLinuxTracing/PerfEventOpen.h
+++ b/OrbitLinuxTracing/PerfEventOpen.h
@@ -91,9 +91,11 @@ static constexpr uint16_t SAMPLE_STACK_USER_SIZE = 65000;
 // perf_event_open for context switches.
 int context_switch_event_open(pid_t pid, int32_t cpu);
 
-// perf_event_open for stack sampling, while collecting task (fork and exit) and
-// mmap records in the same buffer.
-int sample_mmap_task_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
+// perf_event_open for task (fork and exit) and mmap records in the same buffer.
+int mmap_task_event_open(pid_t pid, int32_t cpu);
+
+// perf_event_open for stack sampling.
+int sample_event_open(uint64_t period_ns, pid_t pid, int32_t cpu);
 
 // perf_event_open for uprobes and uretprobes.
 int uprobes_stack_event_open(const char* module, uint64_t function_offset,

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -9,7 +9,7 @@ namespace LinuxTracing {
 // Helper functions for reads from a perf_event_open ring buffer that require
 // more complex operations than simply copying an entire perf_event_open record.
 
-template<typename SamplePerfEventT>
+template <typename SamplePerfEventT>
 inline std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {
   // Data in the ring buffer has the layout of perf_event_stack_sample, but we
@@ -30,6 +30,6 @@ inline std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(
   return event;
 }
 
-}
+}  // namespace LinuxTracing
 
 #endif  // ORBIT_LINUX_TRACING_PERF_EVENT_READERS_H_

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -37,7 +37,7 @@ inline pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
 inline pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer) {
   pid_t pid;
   ring_buffer->ReadValueAtOffset(
-        &pid, offsetof(perf_event_empty_sample, sample_id.pid));
+      &pid, offsetof(perf_event_empty_sample, sample_id.pid));
   return pid;
 }
 

--- a/OrbitLinuxTracing/PerfEventReaders.h
+++ b/OrbitLinuxTracing/PerfEventReaders.h
@@ -9,6 +9,38 @@ namespace LinuxTracing {
 // Helper functions for reads from a perf_event_open ring buffer that require
 // more complex operations than simply copying an entire perf_event_open record.
 
+inline pid_t ReadMmapRecordPid(PerfEventRingBuffer* ring_buffer) {
+  // Mmap records have the following layout:
+  // struct {
+  //   struct perf_event_header header;
+  //   u32    pid, tid;
+  //   u64    addr;
+  //   u64    len;
+  //   u64    pgoff;
+  //   char   filename[];
+  //   struct sample_id sample_id; /* if sample_id_all */
+  // };
+  // Because of filename, the layout is not fixed.
+
+  pid_t pid;
+  ring_buffer->ReadValueAtOffset(&pid, sizeof(perf_event_header));
+  return pid;
+}
+
+inline pid_t ReadSampleRecordPid(PerfEventRingBuffer* ring_buffer) {
+  pid_t pid;
+  ring_buffer->ReadValueAtOffset(
+      &pid, offsetof(perf_event_stack_sample, sample_id.pid));
+  return pid;
+}
+
+inline pid_t ReadUretprobesRecordPid(PerfEventRingBuffer* ring_buffer) {
+  pid_t pid;
+  ring_buffer->ReadValueAtOffset(
+        &pid, offsetof(perf_event_empty_sample, sample_id.pid));
+  return pid;
+}
+
 template <typename SamplePerfEventT>
 inline std::unique_ptr<SamplePerfEventT> ConsumeSamplePerfEvent(
     PerfEventRingBuffer* ring_buffer, const perf_event_header& header) {

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -82,7 +82,7 @@ void TracerThread::Run(
   for (int32_t cpu : cpuset_cpus) {
     int mmap_task_fd = mmap_task_event_open(-1, cpu);
     PerfEventRingBuffer mmap_task_ring_buffer{mmap_task_fd,
-                                              SMALL_RING_BUFFER_SIZE_KB};
+                                              BIG_RING_BUFFER_SIZE_KB};
     if (mmap_task_ring_buffer.IsOpen()) {
       tracing_fds_.push_back(mmap_task_fd);
       ring_buffers_.push_back(std::move(mmap_task_ring_buffer));

--- a/OrbitLinuxTracing/TracerThread.h
+++ b/OrbitLinuxTracing/TracerThread.h
@@ -93,12 +93,9 @@ class TracerThread {
   bool trace_callstacks_ = true;
   bool trace_instrumented_functions_ = true;
 
-  absl::flat_hash_map<int, PerfEventRingBuffer> fds_to_ring_buffer_;
-  absl::flat_hash_map<pid_t, int> threads_to_fd_;
+  std::vector<int> tracing_fds_;
+  std::vector<PerfEventRingBuffer> ring_buffers_;
   absl::flat_hash_map<int, const Function*> uprobes_fds_to_function_;
-  std::vector<std::pair<int, PerfEventRingBuffer>> fds_to_ring_buffer_to_add_;
-  std::vector<int> fds_to_remove_;
-  std::vector<int> uretprobes_fds_;
 
   std::atomic<bool> stop_deferred_thread_ = false;
   std::vector<std::unique_ptr<PerfEvent>> deferred_events_;

--- a/OrbitLinuxTracing/Utils.cpp
+++ b/OrbitLinuxTracing/Utils.cpp
@@ -1,0 +1,150 @@
+#ifndef ORBIT_LINUX_TRACING_UTILS_H_
+#define ORBIT_LINUX_TRACING_UTILS_H_
+
+#include <fstream>
+#include <thread>
+
+#include "Logging.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_split.h"
+
+namespace LinuxTracing {
+
+std::optional<std::string> ReadFile(std::string_view filename) {
+  std::ifstream file(std::string{filename}, std::ios::in | std::ios::binary);
+  if (!file) {
+    ERROR("Could not open \"%s\"", std::string{filename}.c_str());
+    return std::optional<std::string>{};
+  }
+
+  std::ostringstream content;
+  content << file.rdbuf();
+  return content.str();
+}
+
+std::string ReadMaps(pid_t pid) {
+  std::string maps_filename = absl::StrFormat("/proc/%d/maps", pid);
+  std::optional<std::string> maps_content_opt = ReadFile(maps_filename);
+  if (maps_content_opt.has_value()) {
+    return maps_content_opt.value();
+  } else {
+    return "";
+  }
+}
+
+std::string ExecuteCommand(const std::string& cmd) {
+  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"),
+                                                pclose);
+  if (!pipe) {
+    ERROR("Could not open pipe for \"%s\"", cmd.c_str());
+  }
+
+  std::array<char, 128> buffer;
+  std::string result;
+  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    result += buffer.data();
+  }
+  return result;
+}
+
+std::vector<pid_t> ListThreads(pid_t pid) {
+  std::vector<pid_t> threads;
+  std::string result = ExecuteCommand(absl::StrFormat("ls /proc/%d/task", pid));
+
+  std::stringstream ss(result);
+  std::string line;
+  while (std::getline(ss, line, '\n')) {
+    threads.push_back(std::stol(line));
+  }
+
+  return threads;
+}
+
+int GetNumCores() {
+  int num_cores = static_cast<int>(std::thread::hardware_concurrency());
+  // Some compilers do not support std::thread::hardware_concurrency().
+  if (num_cores != 0) {
+    return num_cores;
+  }
+
+  std::string num_cores_str = ExecuteCommand("nproc");
+  if (!num_cores_str.empty()) {
+    return std::stoi(num_cores_str);
+  }
+
+  return 1;
+}
+
+// Read the cpuset entry in /proc/<pid>/cgroup.
+static std::optional<std::string> GetCgroupCpuset(pid_t pid) {
+  std::string cgroup_filename = absl::StrFormat("/proc/%d/cgroup", pid);
+  std::optional<std::string> cgroup_content_opt = ReadFile(cgroup_filename);
+
+  if (!cgroup_content_opt.has_value()) {
+    return std::optional<std::string>{};
+  }
+  std::istringstream cgroup_content{cgroup_content_opt.value()};
+
+  std::string cgroup_line;
+  while (std::getline(cgroup_content, cgroup_line)) {
+    if (cgroup_line.find("cpuset:") != std::string::npos ||
+        cgroup_line.find("cpuset,") != std::string::npos) {
+      // For example "8:cpuset:/" or "8:cpuset:/game", but potentially also
+      // "5:cpuacct,cpu,cpuset:/daemons".
+      return cgroup_line.substr(cgroup_line.find_last_of(':') + 1);
+    }
+  }
+
+  return std::optional<std::string>{};
+}
+
+static std::optional<std::string> GetCpusetCpusString(
+    const std::string& cgroup_cpuset) {
+  std::string cpuset_cpus_filename =
+      absl::StrFormat("/sys/fs/cgroup/cpuset%s/cpuset.cpus",
+                      cgroup_cpuset == "/" ? "" : cgroup_cpuset);
+  return ReadFile(cpuset_cpus_filename);
+}
+
+static std::vector<int> ParseCpusetCpus(
+    const std::string& cpuset_cpus_content) {
+  std::vector<int> cpuset_cpus{};
+  // Example of format: 0-2,7,12-14
+  for (const auto& range : absl::StrSplit(cpuset_cpus_content, ',')) {
+    std::vector<std::string> values = absl::StrSplit(range, '-');
+    if (values.size() == 1) {
+      int cpu = std::stoi(values[0]);
+      cpuset_cpus.push_back(cpu);
+    } else if (values.size() == 2) {
+      for (int cpu = std::stoi(values[0]); cpu <= std::stoi(values[1]); ++cpu) {
+        cpuset_cpus.push_back(cpu);
+      }
+    }
+  }
+  return cpuset_cpus;
+}
+
+// Read and parse /sys/fs/cgroup/cpuset/<cgroup_cpuset>/cpuset.cpus for the
+// cgroup cpuset of the process with this pid.
+// An empty result indicates an error, as trying to start a process with an
+// empty cpuset fails with message "cgroup change of group failed".
+std::vector<int> GetCpusetCpus(pid_t pid) {
+  // For example "/" or "/game".
+  std::optional<std::string> cgroup_cpuset_opt = GetCgroupCpuset(pid);
+  if (!cgroup_cpuset_opt.has_value()) {
+    return {};
+  }
+
+  // For example "0-2,7,12-14".
+  std::optional<std::string> cpuset_cpus_content_opt =
+      GetCpusetCpusString(cgroup_cpuset_opt.value());
+  if (!cpuset_cpus_content_opt.has_value()) {
+    return {};
+  }
+
+  return ParseCpusetCpus(cpuset_cpus_content_opt.value());
+}
+
+}  // namespace LinuxTracing
+
+#endif  // ORBIT_LINUX_TRACING_UTILS_H_

--- a/OrbitLinuxTracing/Utils.h
+++ b/OrbitLinuxTracing/Utils.h
@@ -3,13 +3,7 @@
 
 #include <unistd.h>
 
-#include <fstream>
 #include <optional>
-#include <thread>
-
-#include "Logging.h"
-#include "absl/strings/str_format.h"
-#include "absl/strings/str_split.h"
 
 namespace LinuxTracing {
 
@@ -19,131 +13,17 @@ inline uint64_t MonotonicTimestampNs() {
   return 1'000'000'000llu * ts.tv_sec + ts.tv_nsec;
 }
 
-inline std::string ExecuteCommand(const std::string& cmd) {
-  std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"),
-                                                pclose);
-  if (!pipe) {
-    ERROR("Could not open pipe for \"%s\"", cmd.c_str());
-  }
+std::string ExecuteCommand(const std::string& cmd);
 
-  std::array<char, 128> buffer;
-  std::string result;
-  while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-    result += buffer.data();
-  }
-  return result;
-}
+std::optional<std::string> ReadFile(std::string_view filename);
 
-inline std::optional<std::string> ReadFile(std::string_view filename) {
-  std::ifstream file(std::string{filename}, std::ios::in | std::ios::binary);
-  if (!file) {
-    ERROR("Could not open \"%s\"", std::string{filename}.c_str());
-    return std::optional<std::string>{};
-  }
+std::string ReadMaps(pid_t pid);
 
-  std::ostringstream content;
-  content << file.rdbuf();
-  return content.str();
-}
+std::vector<pid_t> ListThreads(pid_t pid);
 
-inline std::string ReadMaps(pid_t pid) {
-  std::string maps_filename = absl::StrFormat("/proc/%d/maps", pid);
-  std::optional<std::string> maps_content_opt = ReadFile(maps_filename);
-  if (maps_content_opt.has_value()) {
-    return maps_content_opt.value();
-  } else {
-    return "";
-  }
-}
+int GetNumCores();
 
-inline std::vector<pid_t> ListThreads(pid_t pid) {
-  std::vector<pid_t> threads;
-  std::string result = ExecuteCommand(absl::StrFormat("ls /proc/%d/task", pid));
-
-  std::stringstream ss(result);
-  std::string line;
-  while (std::getline(ss, line, '\n')) {
-    threads.push_back(std::stol(line));
-  }
-
-  return threads;
-}
-
-inline int GetNumCores() {
-  int num_cores = static_cast<int>(std::thread::hardware_concurrency());
-  // Some compilers do not support std::thread::hardware_concurrency().
-  if (num_cores != 0) {
-    return num_cores;
-  }
-
-  std::string num_cores_str = ExecuteCommand("nproc");
-  if (!num_cores_str.empty()) {
-    return std::stoi(num_cores_str);
-  }
-
-  return 1;
-}
-
-// Read the cpuset entry in /proc/<pid>/cgroup.
-inline std::optional<std::string> GetCgroupCpuset(pid_t pid) {
-  std::string cgroup_filename = absl::StrFormat("/proc/%d/cgroup", pid);
-  std::optional<std::string> cgroup_content_opt = ReadFile(cgroup_filename);
-
-  if (!cgroup_content_opt.has_value()) {
-    return std::optional<std::string>{};
-  }
-  std::istringstream cgroup_content{cgroup_content_opt.value()};
-
-  static const std::string CPUSET_SUBSTR = ":cpuset:";
-  std::string cgroup_line;
-  while (std::getline(cgroup_content, cgroup_line)) {
-    size_t cpuset_substr_pos = cgroup_line.find(CPUSET_SUBSTR);
-    if (cpuset_substr_pos != std::string::npos) {
-      // For example "8:cpuset:/" or "8:cpuset:/game".
-      return cgroup_line.substr(cpuset_substr_pos + CPUSET_SUBSTR.size());
-    }
-  }
-
-  return std::optional<std::string>{};
-}
-
-// Read and parse /sys/fs/cgroup/cpuset/<cgroup_cpuset>/cpuset.cpus for the
-// cgroup cpuset of the process with this pid.
-inline std::vector<int> GetCpusetCpus(pid_t pid) {
-  std::optional<std::string> cgroup_cpuset_opt = GetCgroupCpuset(pid);
-  if (!cgroup_cpuset_opt.has_value()) {
-    return {};
-  }
-
-  // For example "/" or "/game".
-  const std::string& cgroup_cpuset = cgroup_cpuset_opt.value();
-
-  std::string cpuset_cpus_filename =
-      absl::StrFormat("/sys/fs/cgroup/cpuset%s/cpuset.cpus",
-                      cgroup_cpuset == "/" ? "" : cgroup_cpuset);
-  std::optional<std::string> cpuset_cpus_content_opt =
-      ReadFile(cpuset_cpus_filename);
-  if (!cpuset_cpus_content_opt.has_value()) {
-    return {};
-  }
-
-  std::string cpuset_cpus_content = cpuset_cpus_content_opt.value();
-  std::vector<int> cpuset_cpus{};
-  // Example of format: 0-2,7,12-14
-  for (const auto& range : absl::StrSplit(cpuset_cpus_content, ',')) {
-    std::vector<std::string> values = absl::StrSplit(range, '-');
-    if (values.size() == 1) {
-      int cpu = std::stoi(values[0]);
-      cpuset_cpus.push_back(cpu);
-    } else if (values.size() == 2) {
-      for (int cpu = std::stoi(values[0]); cpu <= std::stoi(values[1]);
-           ++cpu) {
-        cpuset_cpus.push_back(cpu);
-      }
-    }
-  }
-  return cpuset_cpus;
-}
+std::vector<int> GetCpusetCpus(pid_t pid);
 
 }  // namespace LinuxTracing
 


### PR DESCRIPTION
This is to cut on the number of ring buffers that we need to keep for sampling, especially with a big number of threads.
Only sample the cores that are in the process's cgroup's cpuset.