### PR TITLE
Duplicate uprobe event detection.

### DIFF
--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.cpp
@@ -146,7 +146,7 @@ void UprobesUnwindingVisitor::visit(UprobesWithStackPerfEvent* event) {
 
   // Duplicate uprobe detection.
   uint64_t uprobe_sp = event->GetRegisters()[PERF_REG_X86_SP];
-  std::vector<uint64_t>& uprobe_sps = uprobe_sp_per_thread_[event->GetTid()];
+  std::vector<uint64_t>& uprobe_sps = uprobe_sps_per_thread_[event->GetTid()];
   if (!uprobe_sps.empty()) {
     uint64_t last_uprobe_sp = uprobe_sps.back();
     uprobe_sps.pop_back();
@@ -180,7 +180,7 @@ void UprobesUnwindingVisitor::visit(UprobesWithStackPerfEvent* event) {
 
 void UprobesUnwindingVisitor::visit(UretprobesPerfEvent* event) {
   // Duplicate uprobe detection.
-  std::vector<uint64_t>& uprobe_sps = uprobe_sp_per_thread_[event->GetTid()];
+  std::vector<uint64_t>& uprobe_sps = uprobe_sps_per_thread_[event->GetTid()];
   if (!uprobe_sps.empty()) {
     uprobe_sps.pop_back();
   }

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -118,6 +118,8 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
 
   static std::vector<CallstackFrame> CallstackFramesFromLibunwindstackFrames(
       const std::vector<unwindstack::FrameData>& libunwindstack_frames);
+
+  absl::flat_hash_map<pid_t, std::vector<uint64_t>> uprobe_sp_per_thread_{};
 };
 
 }  // namespace LinuxTracing

--- a/OrbitLinuxTracing/UprobesUnwindingVisitor.h
+++ b/OrbitLinuxTracing/UprobesUnwindingVisitor.h
@@ -119,7 +119,7 @@ class UprobesUnwindingVisitor : public PerfEventVisitor {
   static std::vector<CallstackFrame> CallstackFramesFromLibunwindstackFrames(
       const std::vector<unwindstack::FrameData>& libunwindstack_frames);
 
-  absl::flat_hash_map<pid_t, std::vector<uint64_t>> uprobe_sp_per_thread_{};
+  absl::flat_hash_map<pid_t, std::vector<uint64_t>> uprobe_sps_per_thread_{};
 };
 
 }  // namespace LinuxTracing


### PR DESCRIPTION
We are seeing that on thread migration, uprobe events can sometimes be duplicated.

The idea of the workaround is that for a given thread's sequence of u(ret)probe
events, two consecutive uprobe events must be associated with decreasing stack
pointers (nested function calls, stack grows by decreasing stack pointer).  If
we miss a uretprobe event, or if an extra uprobe event is generated, then the
second uprobe event will be associated with a stack pointer that is greater or
equal to the previous stack pointer, and that's not normal. In that situation,
we discard the second uprobe event.

My guess is that if a context switch happens exactly at the right time when the
uprobe's trampoline is being executed, the uprobe event will be generated on the
original core AND on the core we are migrating to.  This needs further
investigation.