### PR TITLE
Set IsRemote flag for remote processes

### DIFF
--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -169,6 +169,8 @@ void ConnectionManager::SetupServerCallbacks() {
           return;
         }
 
+        Capture::SetTargetProcess(process);
+
         std::vector<ModuleDebugInfo> remoteModuleDebugInfo;
         std::vector<std::string> modules;
 

--- a/OrbitCore/ProcessUtils.cpp
+++ b/OrbitCore/ProcessUtils.cpp
@@ -277,9 +277,9 @@ bool ProcessList::Contains(uint32_t a_PID) const {
 }
 
 //-----------------------------------------------------------------------------
-void ProcessList::SetRemote(bool a_Value) {
+void ProcessList::SetRemote(bool value) {
   for (std::shared_ptr<Process>& process : m_Processes) {
-    process->SetIsRemote(true);
+    process->SetIsRemote(value);
   }
 }
 

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -1242,8 +1242,8 @@ void OrbitApp::OnRemoteProcessList(const Message& a_Message) {
   cereal::JSONInputArchive inputAr(buffer);
   std::shared_ptr<ProcessList> remoteProcessList =
       std::make_shared<ProcessList>();
-  remoteProcessList->SetRemote(true);
   inputAr(*remoteProcessList);
+  remoteProcessList->SetRemote(true);
   GOrbitApp->m_ProcessesDataView->SetRemoteProcessList(remoteProcessList);
 }
 


### PR DESCRIPTION
Set remote flag to true for processes received from remote server.
Previously client ignored that flag of the list of modules was
empty - which is always was since prior 02840a8df9525ff85e30e10041aeb2a8508817ba
the list did not preserve information about loaded modules.

After the change the modules list is preserved and this led to a
situation where the client is incorrectly treating remote processes as
local ones.

This change fixes this problem by setting IsRemote flag on the List
after reading the process list.

Test: build, capture, restart client, capture