### PR TITLE
Optimize LinuxTracingHandler::OnCallstack

### DIFF
--- a/OrbitCore/ConnectionManager.cpp
+++ b/OrbitCore/ConnectionManager.cpp
@@ -236,7 +236,7 @@ void ConnectionManager::SetupClientCallbacks() {
   GTcpClient->AddCallback(Msg_RemoteSymbol, [=](const Message& a_Msg) {
     LinuxSymbol symbol;
     std::istringstream buffer(std::string(a_Msg.m_Data, a_Msg.m_Size));
-    cereal::JSONInputArchive inputAr(buffer);
+    cereal::BinaryInputArchive inputAr(buffer);
     inputAr(symbol);
 
     GCoreApp->AddSymbol(symbol.m_Address, symbol.m_Module, symbol.m_Name);

--- a/OrbitCore/EventBuffer.h
+++ b/OrbitCore/EventBuffer.h
@@ -3,6 +3,8 @@
 //-----------------------------------
 #pragma once
 
+#include <set>
+
 #include "BlockChain.h"
 #include "Callstack.h"
 #include "Core.h"
@@ -12,8 +14,6 @@
 #include "LinuxTracingHandler.h"
 #include "LinuxUtils.h"
 #endif
-
-#include <set>
 
 //-----------------------------------------------------------------------------
 struct CallstackEvent {

--- a/OrbitCore/OrbitProcess.cpp
+++ b/OrbitCore/OrbitProcess.cpp
@@ -4,6 +4,8 @@
 
 #include "OrbitProcess.h"
 
+#include <utility>
+
 #include "Core.h"
 #include "Injection.h"
 #include "OrbitModule.h"
@@ -285,7 +287,7 @@ std::shared_ptr<Module> Process::GetModuleFromName(const std::string& a_Name) {
 //-----------------------------------------------------------------------------
 void Process::AddSymbol(uint64_t a_Address,
                         std::shared_ptr<LinuxSymbol> a_Symbol) {
-  m_Symbols[a_Address] = a_Symbol;
+  m_Symbols[a_Address] = std::move(a_Symbol);
 }
 
 #ifdef _WIN32

--- a/OrbitCore/OrbitProcess.h
+++ b/OrbitCore/OrbitProcess.h
@@ -15,6 +15,7 @@
 #include "ScopeTimer.h"
 #include "SerializationMacros.h"
 #include "Threading.h"
+#include "absl/container/flat_hash_map.h"
 
 #ifdef __linux__
 #include "LinuxUtils.h"
@@ -97,7 +98,7 @@ class Process {
   }
   void AddSymbol(uint64_t a_Address, std::shared_ptr<LinuxSymbol> a_Symbol);
   bool HasSymbol(uint64_t a_Address) const {
-    return m_Symbols.find(a_Address) != m_Symbols.end();
+    return m_Symbols.count(a_Address) > 0;
   }
 
   bool LineInfoFromAddress(DWORD64 a_Address, struct LineInfo& o_LineInfo);
@@ -157,7 +158,7 @@ class Process {
   std::unordered_set<uint32_t> m_ThreadIds;
   std::map<uint32_t, std::string> m_ThreadNames;
 
-  std::map<uint64_t, std::shared_ptr<LinuxSymbol> > m_Symbols;
+  absl::flat_hash_map<uint64_t, std::shared_ptr<LinuxSymbol> > m_Symbols;
 
   // Transients
   std::vector<Function*> m_Functions;

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -277,11 +277,12 @@ void OrbitApp::ProcessSamplingCallStack(LinuxCallstackEvent& a_CallStack) {
       ScopeLock lock(m_SamplingCallstackMutex);
       m_SamplingCallstackBuffer.push_back(a_CallStack);
     }
+  } else {
+    Capture::GSamplingProfiler->AddCallStack(a_CallStack.m_CS);
+    GEventTracer.GetEventBuffer().AddCallstackEvent(
+        a_CallStack.m_time, a_CallStack.m_CS.m_Hash,
+        a_CallStack.m_CS.m_ThreadId);
   }
-
-  Capture::GSamplingProfiler->AddCallStack(a_CallStack.m_CS);
-  GEventTracer.GetEventBuffer().AddCallstackEvent(
-      a_CallStack.m_time, a_CallStack.m_CS.m_Hash, a_CallStack.m_CS.m_ThreadId);
 }
 
 //-----------------------------------------------------------------------------
@@ -289,10 +290,11 @@ void OrbitApp::ProcessHashedSamplingCallStack(CallstackEvent& a_CallStack) {
   if (ConnectionManager::Get().IsService()) {
     ScopeLock lock(m_HashedSamplingCallstackMutex);
     m_HashedSamplingCallstackBuffer.push_back(a_CallStack);
+  } else {
+    Capture::GSamplingProfiler->AddHashedCallStack(a_CallStack);
+    GEventTracer.GetEventBuffer().AddCallstackEvent(
+        a_CallStack.m_Time, a_CallStack.m_Id, a_CallStack.m_TID);
   }
-  Capture::GSamplingProfiler->AddHashedCallStack(a_CallStack);
-  GEventTracer.GetEventBuffer().AddCallstackEvent(
-      a_CallStack.m_Time, a_CallStack.m_Id, a_CallStack.m_TID);
 }
 
 //-----------------------------------------------------------------------------

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -329,7 +329,7 @@ void OrbitApp::AddSymbol(uint64_t a_Address, const std::string& a_Module,
     symbol.m_Module = a_Module;
     symbol.m_Name = a_Name;
     symbol.m_Address = a_Address;
-    std::string messageData = SerializeObjectHumanReadable(symbol);
+    std::string messageData = SerializeObjectBinary(symbol);
     GTcpServer->Send(Msg_RemoteSymbol, (void*)messageData.c_str(),
                      messageData.size());
   }


### PR DESCRIPTION
Some profiling work. That function now takes 9 % of the ProcessDeferredEvents thread down from 20 %.
@pierricgimmig Are the elses added by the second commit correct?