### PR TITLE
Let's treat gte as an external dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ find_package(cereal CONFIG REQUIRED)
 find_package(xxHash REQUIRED)
 find_package(multicore REQUIRED)
 find_package(concurrentqueue REQUIRED)
+find_package(gte REQUIRED)
 
 if(WITH_GUI)
   find_package(freetype CONFIG REQUIRED)

--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -110,6 +110,7 @@ if(WITH_GUI)
            imgui::imgui
            freeglut::freeglut
            capstone::capstone
+           gte::gte
            glew::glew)
 else()
   # Don't build this target by default. It will not compile in a WITH_GUI=OFF
@@ -179,6 +180,6 @@ get_target_property(INT_INC OrbitGl INTERFACE_INCLUDE_DIRECTORIES)
 set_target_properties(OrbitNoGl PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
                                            "${INT_INC}")
 
-target_link_libraries(OrbitNoGl PUBLIC OrbitCore OrbitAsm capstone::capstone)
+target_link_libraries(OrbitNoGl PUBLIC OrbitCore OrbitAsm capstone::capstone gte::gte)
 
 target_compile_definitions(OrbitNoGl PUBLIC NOGL)

--- a/OrbitGl/CoreMath.h
+++ b/OrbitGl/CoreMath.h
@@ -5,9 +5,9 @@
 
 #include <algorithm>
 
-#include "../external/gte/GteVector2.h"
-#include "../external/gte/GteVector3.h"
-#include "../external/gte/GteVector4.h"
+#include "GteVector2.h"
+#include "GteVector3.h"
+#include "GteVector4.h"
 
 typedef gte::Vector2<float> Vec2;
 typedef gte::Vector3<float> Vec3;

--- a/cmake/Findgte.cmake
+++ b/cmake/Findgte.cmake
@@ -1,0 +1,6 @@
+add_library(gte INTERFACE)
+
+set(DIR external/gte)
+target_include_directories(gte SYSTEM INTERFACE ${DIR})
+
+add_library(gte::gte ALIAS gte)


### PR DESCRIPTION
`external/gte` slipped through when I made the cmake changes. And now I'm making up for this.

* Added `cmake/Findgte.cmake`
* Added `find_package` call to main CMakeLists.txt and `target_link_libraries` call
* Adjusted includes

Test: Compiles on Linux and Windows, cross compiles for GGP