### PR TITLE
Conan recipes for grpc

### DIFF
--- a/contrib/conan/recipes/grpc/CMakeLists.txt
+++ b/contrib/conan/recipes/grpc/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_program(_gRPC_PROTOBUF_PROTOC_EXECUTABLE protoc)
+set(_gRPC_PROTOBUF_PROTOC_LIBRARIES CONAN_PKG::protobuf)
+set(_gRPC_PROTOBUF_LIBRARIES CONAN_PKG::protobuf)
+get_target_property(_gRPC_PROTOBUF_WELLKNOWN_INCLUDE_DIR CONAN_PKG::protobuf INTERFACE_INCLUDE_DIRECTORIES)
+list(GET _gRPC_PROTOBUF_WELLKNOWN_INCLUDE_DIR 0 _gRPC_PROTOBUF_WELLKNOWN_INCLUDE_DIR)
+
+set(OPENSSL_ROOT_DIR "${CONAN_OPENSSL_ROOT}")
+list(APPEND CMAKE_FIND_ROOT_PATH "${CONAN_OPENSSL_ROOT}")
+
+add_subdirectory("source_subfolder")

--- a/contrib/conan/recipes/grpc/LICENSE.md
+++ b/contrib/conan/recipes/grpc/LICENSE.md
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Malte Haase
+Copyright (c) 2017 - 2019 Inexor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contrib/conan/recipes/grpc/README.md
+++ b/contrib/conan/recipes/grpc/README.md
@@ -1,0 +1,41 @@
+# A short introduction on how to use the `grpc` conan package
+
+1. Add `grpc/1.27.3@orbitdeps/stable` to the requirements of your project by
+   editing your project's `conanfile.py` and add the dependency to the 
+   `requires` attribute. If your conanfile defines a `def requirements(self):`
+   function add a `self.requires('grpc/1.27.3@orbitdeps/stable')` call to this
+   function. The latter is the case for Orbit.
+
+2. Add `grpc_codegen/1.27.3@orbitdeps/stable` to the build requirements of your
+   project by editing your project's `conanfile.py` and add the build dependency
+   to the `build_requires` attribute. Example:
+   `build_requires = 'grpc_codegen/1.27.3@orbitdeps/stable'`.
+
+3. Add some `find_package` calls to your top-level `CMakeLists.txt`-file:
+   ```cmake
+   find_package(protobuf CONFIG REQUIRED)
+   find_package(gRPC CONFIG REQUIRED)
+   ```
+
+4. Add your `.proto`-files as `PRVIATE` source files to your cmake-targets and
+   call `grpc_helper` on this target. Example:
+   ```cmake
+   add_executable(test)
+   target_sources(test PRIVATE main.cpp test.proto)
+   grpc_helper(test)
+   ```
+   The `grpc_helper`-call will properly call the protobuf-compiler with the
+   grpc-cpp-plugin enabled and will feed the resulting C++-files back into the
+   cmake-target.
+
+
+## Limitations
+
+Currently the protobuf-compiler include path is hard-coded to the directory
+containing the main `.proto` file.  It would be no problem to inherit the
+include directories from the `cmake`-target. Ping me, if necessary.
+
+## Example
+
+Check out `examples/helloworld/` for a small self-sustaining conan- and cmake-
+based `grpc`-example.

--- a/contrib/conan/recipes/grpc/conandata.yml
+++ b/contrib/conan/recipes/grpc/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.25.0":
+    url: https://github.com/grpc/grpc/archive/v1.25.0.zip
+    sha256: 82de7c3754df7be44c65fd00decd5e2351ea64e4d21fdaf6d76cea5676f954e8
+  "1.27.3":
+    url: https://github.com/grpc/grpc/archive/v1.27.3.zip
+    sha256: bad0de89c09137704821818f5d25566ee4c58698e99e3df67e878ef5da221159

--- a/contrib/conan/recipes/grpc/conanfile.py
+++ b/contrib/conan/recipes/grpc/conanfile.py
@@ -1,0 +1,134 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+import shutil
+import time
+import platform
+
+
+class grpcConan(ConanFile):
+    name = "grpc"
+    version = "1.27.3"
+    description = "Google's RPC library and framework."
+    topics = ("conan", "grpc", "rpc")
+    url = "https://github.com/inexorgame/conan-grpc"
+    homepage = "https://github.com/grpc/grpc"
+    license = "Apache-2.0"
+    exports_sources = ["CMakeLists.txt", "gRPCTargets-helpers.cmake"]
+    generators = "cmake"
+    short_paths = True  # Otherwise some folders go out of the 260 chars path length scope rapidly (on windows)
+
+    settings = "os", "arch", "compiler", "arch"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+
+    requires = (
+        "abseil/20190808@orbitdeps/stable",
+        "zlib/1.2.11",
+        "openssl/1.0.2t",
+        "protobuf/3.9.1@bincrafters/stable",
+        "c-ares/1.15.0@conan/stable"
+    )
+
+    build_requires = (
+        "grpc_codegen/{}@orbitdeps/stable".format(version),
+    )
+
+    def configure(self):
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            del self.options.fPIC
+            compiler_version = int(str(self.settings.compiler.version))
+            if compiler_version < 14:
+                raise ConanInvalidConfiguration("gRPC can only be built with Visual Studio 2015 or higher.")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "grpc-" + self.version
+        if platform.system() == "Windows":
+            time.sleep(8) # Work-around, see https://github.com/conan-io/conan/issues/5205
+        os.rename(extracted_dir, self._source_subfolder)
+
+        cmake_path = os.path.join(self._source_subfolder, "CMakeLists.txt")
+        tools.replace_in_file(cmake_path, "absl::strings", "CONAN_PKG::abseil")
+        tools.replace_in_file(cmake_path, "absl::optional", "CONAN_PKG::abseil")
+        tools.replace_in_file(cmake_path, "absl::inlined_vector", "CONAN_PKG::abseil")
+        tools.replace_in_file(cmake_path, "set(_gRPC_CPP_PLUGIN $<TARGET_FILE:grpc_cpp_plugin>)", "find_program(_gRPC_CPP_PLUGIN grpc_cpp_plugin)")
+        tools.replace_in_file(cmake_path, "DEPENDS ${ABS_FIL} ${_gRPC_PROTOBUF_PROTOC} grpc_cpp_plugin", "DEPENDS ${ABS_FIL} ${_gRPC_PROTOBUF_PROTOC} ${_gRPC_CPP_PLUGIN}")
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+
+        cmake.definitions['gRPC_BUILD_CODEGEN'] = "ON"
+        cmake.definitions['gRPC_BUILD_CSHARP_EXT'] = "OFF"
+        cmake.definitions['gRPC_BUILD_TESTS'] = "OFF"
+        cmake.definitions['gRPC_INSTALL'] = "ON"
+
+        cmake.definitions["gRPC_BUILD_GRPC_CPP_PLUGIN"] = "OFF"
+        cmake.definitions["gRPC_BUILD_GRPC_CSHARP_PLUGIN"] = "OFF"
+        cmake.definitions["gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN"] = "OFF"
+        cmake.definitions["gRPC_BUILD_GRPC_PHP_PLUGIN"] = "OFF"
+        cmake.definitions["gRPC_BUILD_GRPC_PYTHON_PLUGIN"] = "OFF"
+        cmake.definitions["gRPC_BUILD_GRPC_RUBY_PLUGIN"] = "OFF"
+        cmake.definitions["gRPC_BUILD_GRPC_NODE_PLUGIN"] = "OFF"
+
+        # tell grpc to use the find_package versions
+        cmake.definitions['gRPC_CARES_PROVIDER'] = "package"
+        cmake.definitions['gRPC_ZLIB_PROVIDER'] = "package"
+        cmake.definitions['gRPC_SSL_PROVIDER'] = "package"
+        cmake.definitions['gRPC_PROTOBUF_PROVIDER'] = "none"
+        cmake.definitions['gRPC_ABSL_PROVIDER'] = "none"
+
+        # Workaround for https://github.com/grpc/grpc/issues/11068
+        cmake.definitions['gRPC_GFLAGS_PROVIDER'] = "none"
+        cmake.definitions['gRPC_BENCHMARK_PROVIDER'] = "none"
+
+        # Compilation on minGW GCC requires to set _WIN32_WINNTT to at least 0x600
+        # https://github.com/grpc/grpc/blob/109c570727c3089fef655edcdd0dd02cc5958010/include/grpc/impl/codegen/port_platform.h#L44
+        if self.settings.os == "Windows" and self.settings.compiler == "gcc":
+            cmake.definitions["CMAKE_CXX_FLAGS"] = "-D_WIN32_WINNT=0x600"
+            cmake.definitions["CMAKE_C_FLAGS"] = "-D_WIN32_WINNT=0x600"
+
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        shutil.rmtree(os.path.join(self.package_folder, "lib", "pkgconfig"))
+        shutil.rmtree(os.path.join(self.package_folder, "lib", "cmake", "grpc", "modules"))
+
+        self.copy("gRPCTargets-helpers.cmake", dst=os.path.join("lib", "cmake", "grpc"))
+        self.copy("LICENSE*", src=self._source_subfolder, dst="licenses")
+
+    def package_info(self):
+        self.cpp_info.libs = [
+            "grpc++_unsecure",
+            "grpc++_reflection",
+            "grpc++_error_details",
+            "grpc++",
+            "grpc_unsecure",
+            "grpc_plugin_support",
+            "grpc_cronet",
+            "grpcpp_channelz",
+            "grpc",
+            "gpr",
+            "address_sorting",
+            "upb",
+        ]
+
+
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.system_libs += ["wsock32", "ws2_32"]
+

--- a/contrib/conan/recipes/grpc/examples/helloworld/CMakeLists.txt
+++ b/contrib/conan/recipes/grpc/examples/helloworld/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(test C CXX)
+
+if(MSVC)
+	add_definitions(-D_WIN32_WINNT=0x600)
+endif()
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+list(PREPEND CMAKE_FIND_ROOT_PATH ${CONAN_OPENSSL_ROOT})
+
+find_package(protobuf CONFIG REQUIRED)
+find_package(gRPC CONFIG REQUIRED)
+
+add_executable(server)
+target_sources(server PRIVATE
+        greeter_server.cpp
+        helloworld.proto)
+grpc_helper(server)
+
+add_executable(client)
+target_sources(client PRIVATE
+        greeter_client.cpp
+        helloworld.proto)
+grpc_helper(client)

--- a/contrib/conan/recipes/grpc/examples/helloworld/conanfile.py
+++ b/contrib/conan/recipes/grpc/examples/helloworld/conanfile.py
@@ -1,0 +1,17 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class HelloWorldConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "cmake"
+    name = "helloworld"
+    version = "0.0.1"
+
+    requires = "grpc/1.27.3@orbitdeps/stable"
+    build_requires = "grpc_codegen/1.27.3@orbitdeps/stable"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()

--- a/contrib/conan/recipes/grpc/examples/helloworld/greeter_client.cpp
+++ b/contrib/conan/recipes/grpc/examples/helloworld/greeter_client.cpp
@@ -1,0 +1,103 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+
+#include "helloworld.grpc.pb.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+using helloworld::HelloRequest;
+using helloworld::HelloReply;
+using helloworld::Greeter;
+
+class GreeterClient {
+ public:
+  GreeterClient(std::shared_ptr<Channel> channel)
+      : stub_(Greeter::NewStub(channel)) {}
+
+  // Assembles the client's payload, sends it and presents the response back
+  // from the server.
+  std::string SayHello(const std::string& user) {
+    // Data we are sending to the server.
+    HelloRequest request;
+    request.set_name(user);
+
+    // Container for the data we expect from the server.
+    HelloReply reply;
+
+    // Context for the client. It could be used to convey extra information to
+    // the server and/or tweak certain RPC behaviors.
+    ClientContext context;
+
+    // The actual RPC.
+    Status status = stub_->SayHello(&context, request, &reply);
+
+    // Act upon its status.
+    if (status.ok()) {
+      return reply.message();
+    } else {
+      std::cout << status.error_code() << ": " << status.error_message()
+                << std::endl;
+      return "RPC failed";
+    }
+  }
+
+ private:
+  std::unique_ptr<Greeter::Stub> stub_;
+};
+
+int main(int argc, char** argv) {
+  // Instantiate the client. It requires a channel, out of which the actual RPCs
+  // are created. This channel models a connection to an endpoint specified by
+  // the argument "--target=" which is the only expected argument.
+  // We indicate that the channel isn't authenticated (use of
+  // InsecureChannelCredentials()).
+  std::string target_str;
+  std::string arg_str("--target");
+  if (argc > 1) {
+    std::string arg_val = argv[1];
+    size_t start_pos = arg_val.find(arg_str);
+    if (start_pos != std::string::npos) {
+      start_pos += arg_str.size();
+      if (arg_val[start_pos] == '=') {
+        target_str = arg_val.substr(start_pos + 1);
+      } else {
+        std::cout << "The only correct argument syntax is --target=" << std::endl;
+        return 0;
+      }
+    } else {
+      std::cout << "The only acceptable argument is --target=" << std::endl;
+      return 0;
+    }
+  } else {
+    target_str = "localhost:50051";
+  }
+  GreeterClient greeter(grpc::CreateChannel(
+      target_str, grpc::InsecureChannelCredentials()));
+  std::string user("world");
+  std::string reply = greeter.SayHello(user);
+  std::cout << "Greeter received: " << reply << std::endl;
+
+  return 0;
+}

--- a/contrib/conan/recipes/grpc/examples/helloworld/greeter_server.cpp
+++ b/contrib/conan/recipes/grpc/examples/helloworld/greeter_server.cpp
@@ -1,0 +1,72 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/health_check_service_interface.h>
+#include <grpcpp/ext/proto_server_reflection_plugin.h>
+
+#include "helloworld.grpc.pb.h"
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::Status;
+using helloworld::HelloRequest;
+using helloworld::HelloReply;
+using helloworld::Greeter;
+
+// Logic and data behind the server's behavior.
+class GreeterServiceImpl final : public Greeter::Service {
+  Status SayHello(ServerContext* context, const HelloRequest* request,
+                  HelloReply* reply) override {
+    std::string prefix("Hello ");
+    reply->set_message(prefix + request->name());
+    return Status::OK;
+  }
+};
+
+void RunServer() {
+  std::string server_address("0.0.0.0:50051");
+  GreeterServiceImpl service;
+
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+  ServerBuilder builder;
+  // Listen on the given address without any authentication mechanism.
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+  // Register "service" as the instance through which we'll communicate with
+  // clients. In this case it corresponds to an *synchronous* service.
+  builder.RegisterService(&service);
+  // Finally assemble the server.
+  std::unique_ptr<Server> server(builder.BuildAndStart());
+  std::cout << "Server listening on " << server_address << std::endl;
+
+  // Wait for the server to shutdown. Note that some other thread must be
+  // responsible for shutting down the server for this call to ever return.
+  server->Wait();
+}
+
+int main(int argc, char** argv) {
+  RunServer();
+
+  return 0;
+}

--- a/contrib/conan/recipes/grpc/examples/helloworld/helloworld.proto
+++ b/contrib/conan/recipes/grpc/examples/helloworld/helloworld.proto
@@ -1,0 +1,38 @@
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
+option objc_class_prefix = "HLW";
+
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}

--- a/contrib/conan/recipes/grpc/gRPCTargets-helpers.cmake
+++ b/contrib/conan/recipes/grpc/gRPCTargets-helpers.cmake
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.12)
+
+function(grpc_helper)
+  find_program(_HELPER_PROTOC protoc)
+  find_program(_HELPER_GRPC_CPP_PLUGIN grpc_cpp_plugin)
+
+  get_target_property(_sources ${ARGV0} SOURCES)
+
+  foreach(source_file ${_sources})
+    if(source_file MATCHES ".*\.proto")
+      string(REGEX REPLACE "[./:;]" "_" target_name ${source_file})
+      set(target_name "_grpc_${target_name}")
+
+      if(NOT TARGET ${target_name})
+        get_filename_component(basename ${source_file} NAME_WE)
+
+        get_filename_component(src_filepath ${source_file} ABSOLUTE)
+        get_filename_component(src_folder ${src_filepath} PATH)
+
+        set(bin_dir "${CMAKE_CURRENT_BINARY_DIR}/grpc_codegen")
+        set(proto_cpp "${bin_dir}/${basename}.pb.cc")
+        set(proto_h "${bin_dir}/${basename}.pb.h")
+        set(grpc_cpp "${bin_dir}/${basename}.grpc.pb.cc")
+        set(grpc_h "${bin_dir}/${basename}.grpc.pb.h")
+
+        add_custom_command(
+          OUTPUT "${bin_dir}" COMMAND ${CMAKE_COMMAND} ARGS -E make_directory
+                                      "${bin_dir}")
+
+        add_custom_command(
+          OUTPUT "${proto_cpp}" "${proto_h}" "${grpc_cpp}" "${grpc_h}"
+          COMMAND
+            ${_HELPER_PROTOC} ARGS --grpc_out "${bin_dir}" --cpp_out
+            "${bin_dir}" -I ${src_folder}
+            --plugin=protoc-gen-grpc="${_HELPER_GRPC_CPP_PLUGIN}"
+            "${src_filepath}"
+          DEPENDS "${source_filepath}" "${bin_dir}")
+
+        add_library(${target_name} OBJECT)
+        target_include_directories(${target_name} PUBLIC ${bin_dir})
+        target_link_libraries(
+          ${target_name} PUBLIC gRPC::grpc++_reflection gRPC::grpc++_unsecure
+                                protobuf::libprotobuf)
+        target_sources(${target_name} PRIVATE "${proto_cpp}" "${grpc_cpp}")
+        target_sources(${target_name} PUBLIC "${proto_h}" "${grpc_h}")
+
+      endif()
+
+      target_link_libraries(${ARGV0} PUBLIC ${target_name})
+    endif()
+  endforeach()
+
+  list(FILTER _sources EXCLUDE REGEX ".*\.proto")
+  set_target_properties(${ARGV0} PROPERTIES SOURCES ${_sources})
+endfunction()

--- a/contrib/conan/recipes/grpc_codegen/CMakeLists.txt
+++ b/contrib/conan/recipes/grpc_codegen/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 2.8.12)
+project(cmake_wrapper)
+
+include(conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+find_program(_gRPC_PROTOBUF_PROTOC_EXECUTABLE protoc)
+set(_gRPC_PROTOBUF_PROTOC_LIBRARIES CONAN_PKG::protobuf)
+set(_gRPC_PROTOBUF_LIBRARIES CONAN_PKG::protobuf)
+get_target_property(_gRPC_PROTOBUF_WELLKNOWN_INCLUDE_DIR CONAN_PKG::protobuf INTERFACE_INCLUDE_DIRECTORIES)
+list(GET _gRPC_PROTOBUF_WELLKNOWN_INCLUDE_DIR 0 _gRPC_PROTOBUF_WELLKNOWN_INCLUDE_DIR)
+
+add_subdirectory("source_subfolder")

--- a/contrib/conan/recipes/grpc_codegen/LICENSE.md
+++ b/contrib/conan/recipes/grpc_codegen/LICENSE.md
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Malte Haase
+Copyright (c) 2017 - 2019 Inexor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contrib/conan/recipes/grpc_codegen/conandata.yml
+++ b/contrib/conan/recipes/grpc_codegen/conandata.yml
@@ -1,0 +1,7 @@
+sources:
+  "1.25.0":
+    url: https://github.com/grpc/grpc/archive/v1.25.0.zip
+    sha256: 82de7c3754df7be44c65fd00decd5e2351ea64e4d21fdaf6d76cea5676f954e8
+  "1.27.3":
+    url: https://github.com/grpc/grpc/archive/v1.27.3.zip
+    sha256: bad0de89c09137704821818f5d25566ee4c58698e99e3df67e878ef5da221159

--- a/contrib/conan/recipes/grpc_codegen/conanfile.py
+++ b/contrib/conan/recipes/grpc_codegen/conanfile.py
@@ -1,0 +1,105 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+import time
+import platform
+
+
+class grpcConan(ConanFile):
+    name = "grpc_codegen"
+    version = "1.27.3"
+    description = "Google's RPC library and framework."
+    topics = ("conan", "grpc", "rpc")
+    url = "https://github.com/inexorgame/conan-grpc"
+    homepage = "https://github.com/grpc/grpc"
+    license = "Apache-2.0"
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    short_paths = True  # Otherwise some folders go out of the 260 chars path length scope rapidly (on windows)
+
+    settings = "os_build", "arch_build", "compiler", "arch"
+    options = {
+        "fPIC": [True, False],
+    }
+    default_options = {
+        "fPIC": True,
+    }
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+
+    requires = (
+        "abseil/20190808@orbitdeps/stable",
+        "zlib/1.2.11",
+        "openssl/1.0.2t",
+        "protobuf/3.9.1@bincrafters/stable",
+        "c-ares/1.15.0@conan/stable",
+        "protoc_installer/3.9.1@bincrafters/stable"
+    )
+
+    def configure(self):
+        if self.settings.os_build == "Windows" and self.settings.compiler == "Visual Studio":
+            del self.options.fPIC
+            compiler_version = int(str(self.settings.compiler.version))
+            if compiler_version < 14:
+                raise ConanInvalidConfiguration("gRPC can only be built with Visual Studio 2015 or higher.")
+
+    def source(self):
+        tools.get(**self.conan_data["sources"][self.version])
+        extracted_dir = "grpc-" + self.version
+        if platform.system() == "Windows":
+            time.sleep(8) # Work-around, see https://github.com/conan-io/conan/issues/5205
+        os.rename(extracted_dir, self._source_subfolder)
+
+        cmake_path = os.path.join(self._source_subfolder, "CMakeLists.txt")
+        tools.replace_in_file(cmake_path, "absl::strings", "CONAN_PKG::abseil")
+        tools.replace_in_file(cmake_path, "absl::optional", "CONAN_PKG::abseil")
+        tools.replace_in_file(cmake_path, "absl::inlined_vector", "CONAN_PKG::abseil")
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+
+        cmake.definitions['gRPC_BUILD_CODEGEN'] = "ON"
+        cmake.definitions['gRPC_BUILD_CSHARP_EXT'] = "OFF"
+        cmake.definitions['gRPC_BUILD_TESTS'] = "OFF"
+        cmake.definitions['gRPC_INSTALL'] = "OFF"
+
+        # tell grpc to use the find_package versions
+        cmake.definitions['gRPC_CARES_PROVIDER'] = "package"
+        cmake.definitions['gRPC_ZLIB_PROVIDER'] = "package"
+        cmake.definitions['gRPC_SSL_PROVIDER'] = "package"
+        cmake.definitions['gRPC_PROTOBUF_PROVIDER'] = "none"
+        cmake.definitions['gRPC_ABSL_PROVIDER'] = "none"
+
+        # Workaround for https://github.com/grpc/grpc/issues/11068
+        cmake.definitions['gRPC_GFLAGS_PROVIDER'] = "none"
+        cmake.definitions['gRPC_BENCHMARK_PROVIDER'] = "none"
+
+        # Compilation on minGW GCC requires to set _WIN32_WINNTT to at least 0x600
+        # https://github.com/grpc/grpc/blob/109c570727c3089fef655edcdd0dd02cc5958010/include/grpc/impl/codegen/port_platform.h#L44
+        if self.settings.os_build == "Windows" and self.settings.compiler == "gcc":
+            cmake.definitions["CMAKE_CXX_FLAGS"] = "-D_WIN32_WINNT=0x600"
+            cmake.definitions["CMAKE_C_FLAGS"] = "-D_WIN32_WINNT=0x600"
+
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        #cmake = self._configure_cmake()
+        #cmake.install()
+
+        self.copy(pattern="LICENSE", dst="licenses")
+        self.copy("*", dst="bin", src=os.path.join(self._build_subfolder, "bin"))
+
+    def package_info(self):
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+
+    def package_id(self):
+        del self.info.settings.compiler
+        del self.info.settings.arch
+        self.info.include_build_settings()
+


### PR DESCRIPTION
This PR adds conan recipes for gRPC and gRPC's protobuf-compiler-plugin.

There are already packages for `libprotobuf` and the protobuf-compiler `protoc` in bincrafters,
so there is no need to manage these recipes by ourselves.

Since these packages are not yet needed in Orbit, I haven't added them as dependencies yet.
But there is a `README.md` file in `contrib/conan/recipes/grpc/`  which explains how to
integrate the package into Orbit or any other project.

I've written a helper script which allows to add `.proto`-files as source files to cmake targets
and magic takes care of calling the protobuf-compiler and of include paths and linking. Check
out the `README.md` on how to enable this for your target.

Additionally in `contrib/conan/recipes/grpc/examples/helloworld/` there is an example which demonstrates how to consume the grpc conan package.

Recipes have been pushed to bintray, binary packages not yet.

Tests: 
* The packages and the example build on all three platforms (Linux, GGP Linux, Windows).
* The example runs on all three platforms.