### PR TITLE
Orbit introspection through manual instrumentation

### DIFF
--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#define ORBIT_TRACING_ENABLED 1
+#define ORBIT_TRACING_ENABLED 0
 
 #if ORBIT_TRACING_ENABLED
 
@@ -58,6 +58,6 @@ struct Scope {
 #define ORBIT_END
 #define ORBIT_TRACK(var)
 
-#endif
+#endif  // ORBIT_TRACING_ENABLED
 
 #endif  // ORBIT_TRACING_TRACING_H_

--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -1,0 +1,62 @@
+#ifndef ORBIT_TRACING_TRACING_H_
+#define ORBIT_TRACING_TRACING_H_
+
+#include <memory>
+
+#define ORBIT_TRACING_ENABLED 1
+
+#if ORBIT_TRACING_ENABLED
+
+// Scoped trace with user defined name.
+#define ORBIT_SCOPE(name) orbit::tracing::Scope ORBIT_UNIQUE(ORB)(name)
+// Scoped trace with calling function name.
+#define ORBIT_SCOPE_FUNC ORBIT_SCOPE(__FUNCTION__)
+// Manual scope begin.
+#define ORBIT_BEGIN(name) ORBIT_CALL(Begin(name))
+// Manual scope end.
+#define ORBIT_END ORBIT_CALL(End())
+// Track named variable (int or float).
+#define ORBIT_TRACK(name, var) ORBIT_CALL(Track(name, var))
+
+// Internal macros.
+#define ORBIT_CONCAT_IND(x, y) (x##y)
+#define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
+#define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
+#define ORBIT_CALL(f)           \
+  if (orbit::tracing::GHandler) { \
+    orbit::tracing::GHandler->f;  \
+  }
+
+namespace orbit {
+namespace tracing {
+
+class Handler {
+ public:
+  virtual void Begin(const char* name) = 0;
+  virtual void End() = 0;
+  virtual void Track(const char* name, int) = 0;
+  virtual void Track(const char* name, float) = 0;
+};
+
+// This must be instanciated in user code.
+extern std::unique_ptr<Handler> GHandler;
+
+struct Scope {
+  Scope(const char* name) { ORBIT_BEGIN(name); }
+  ~Scope() { ORBIT_END; }
+};
+
+}  // namespace tracing
+}  // namespace orbit
+
+#else
+
+#define ORBIT_SCOPE(name)
+#define ORBIT_SCOPE_FUNC
+#define ORBIT_BEGIN(name)
+#define ORBIT_END
+#define ORBIT_TRACK(var)
+
+#endif
+
+#endif  // ORBIT_TRACING_TRACING_H_

--- a/OrbitBase/include/OrbitBase/Tracing.h
+++ b/OrbitBase/include/OrbitBase/Tracing.h
@@ -22,7 +22,7 @@
 #define ORBIT_CONCAT_IND(x, y) (x##y)
 #define ORBIT_CONCAT(x, y) ORBIT_CONCAT_IND(x, y)
 #define ORBIT_UNIQUE(x) ORBIT_CONCAT(x, __COUNTER__)
-#define ORBIT_CALL(f)           \
+#define ORBIT_CALL(f)             \
   if (orbit::tracing::GHandler) { \
     orbit::tracing::GHandler->f;  \
   }
@@ -32,13 +32,14 @@ namespace tracing {
 
 class Handler {
  public:
+  virtual ~Handler() {}
   virtual void Begin(const char* name) = 0;
   virtual void End() = 0;
   virtual void Track(const char* name, int) = 0;
   virtual void Track(const char* name, float) = 0;
 };
 
-// This must be instanciated in user code.
+// This must be instantiated in user code.
 extern std::unique_ptr<Handler> GHandler;
 
 struct Scope {

--- a/OrbitCore/CMakeLists.txt
+++ b/OrbitCore/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(
          FunctionStats.h
          Hashing.h
          Injection.h
+         Introspection.h
          LinuxCallstackEvent.h
          LinuxSymbol.h
          Log.h
@@ -83,6 +84,7 @@ target_sources(
           EventBuffer.cpp
           FunctionStats.cpp
           Injection.cpp
+          Introspection.cpp
           LinuxCallstackEvent.cpp
           Log.cpp
           LogInterface.cpp

--- a/OrbitCore/Introspection.cpp
+++ b/OrbitCore/Introspection.cpp
@@ -1,0 +1,35 @@
+#include "Introspection.h"
+
+#include <memory>
+#include <vector>
+
+#include "CoreApp.h"
+#include "PrintVar.h"
+#include "Utils.h"
+
+namespace orbit {
+namespace introspection {
+
+thread_local std::vector<Scope> scopes;
+
+void Handler::Begin(const char* name) {
+  scopes.emplace_back(Scope{Timer(), name});
+  scopes.back().timer_.Start();
+}
+
+void Handler::End() {
+  Scope& scope = scopes.back();
+  scope.timer_.Stop();
+  scope.timer_.m_Type = Timer::INTROSPECTION;
+  scope.timer_.EncodeString(scope.name_.c_str());
+  scope.timer_.m_Depth = scopes.size() - 1;
+  GCoreApp->ProcessTimer(scope.timer_, scope.name_);
+  scopes.pop_back();
+}
+
+void Handler::Track(const char* name, int) {}
+
+void Handler::Track(const char* name, float) {}
+
+}  // namespace introspection
+}  // namespace orbit

--- a/OrbitCore/Introspection.cpp
+++ b/OrbitCore/Introspection.cpp
@@ -1,5 +1,7 @@
 #include "Introspection.h"
 
+#if ORBIT_TRACING_ENABLED
+
 #include <memory>
 #include <vector>
 
@@ -33,3 +35,5 @@ void Handler::Track(const char* name, float) {}
 
 }  // namespace introspection
 }  // namespace orbit
+
+#endif  // ORBIT_TRACING_ENABLED

--- a/OrbitCore/Introspection.h
+++ b/OrbitCore/Introspection.h
@@ -4,6 +4,8 @@
 #include <OrbitBase/Tracing.h>
 #include "ScopeTimer.h"
 
+#if ORBIT_TRACING_ENABLED
+
 namespace orbit {
 namespace introspection {
 
@@ -21,5 +23,7 @@ struct Scope {
 
 }  // namespace introspection
 }  // namespace orbit
+
+#endif  // ORBIT_TRACING_ENABLED
 
 #endif  // ORBIT_CORE_INTROSPECTION_H_

--- a/OrbitCore/Introspection.h
+++ b/OrbitCore/Introspection.h
@@ -1,0 +1,25 @@
+#ifndef ORBIT_CORE_INTROSPECTION_H_
+#define ORBIT_CORE_INTROSPECTION_H_
+
+#include <OrbitBase/Tracing.h>
+#include "ScopeTimer.h"
+
+namespace orbit {
+namespace introspection {
+
+class Handler : public orbit::tracing::Handler {
+  void Begin(const char* name) final;
+  void End() final;
+  void Track(const char* name, int) final;
+  void Track(const char* name, float) final;
+};
+
+struct Scope {
+  Timer timer_;
+  std::string name_;
+};
+
+}  // namespace introspection
+}  // namespace orbit
+
+#endif  // ORBIT_CORE_INTROSPECTION_H_

--- a/OrbitCore/Profiling.h
+++ b/OrbitCore/Profiling.h
@@ -21,7 +21,7 @@ inline void clock_gettime(uint32_t, struct timespec* spec) {
 #endif
 
 //-----------------------------------------------------------------------------
-inline TickType OrbitTicks(uint32_t a_Clock = 0 /*CLOCK_REALTIME*/) {
+inline TickType OrbitTicks(uint32_t a_Clock = 1 /*CLOCK_MONOTONIC*/) {
   timespec ts;
   clock_gettime(a_Clock, &ts);
   return 1000000000ll * ts.tv_sec + ts.tv_nsec;

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -60,13 +60,18 @@ class Timer {
     UNREAL_OBJECT,
     ZONE,
     ALLOC,
-    FREE
+    FREE,
+    INTROSPECTION,
   };
 
   Type GetType() const { return m_Type; }
   void SetType(Type a_Type) { m_Type = a_Type; }
   bool IsType(Type a_Type) const { return m_Type == a_Type; }
   bool IsCoreActivity() const { return m_Type == CORE_ACTIVITY; }
+
+  char* EncodedString(){ return reinterpret_cast<char*>(&m_UserData); }
+  const char* EncodedString() const { return reinterpret_cast<const char*>(&m_UserData); }
+  void EncodeString(const char* msg) { strncpy(EncodedString(), msg, sizeof(m_UserData)-1); }
 
  public:
   // Needs to have to exact same layout in win32/x64, debug/release

--- a/OrbitCore/ScopeTimer.h
+++ b/OrbitCore/ScopeTimer.h
@@ -69,6 +69,8 @@ class Timer {
   bool IsType(Type a_Type) const { return m_Type == a_Type; }
   bool IsCoreActivity() const { return m_Type == CORE_ACTIVITY; }
 
+  // TODO: implement better mechanism to associate strings to timers.  In the
+  //       mean time, m_UserData can hold (sizeof(m_UserData)-1) characters.
   char* EncodedString(){ return reinterpret_cast<char*>(&m_UserData); }
   const char* EncodedString() const { return reinterpret_cast<const char*>(&m_UserData); }
   void EncodeString(const char* msg) { strncpy(EncodedString(), msg, sizeof(m_UserData)-1); }

--- a/OrbitGl/App.cpp
+++ b/OrbitGl/App.cpp
@@ -442,12 +442,14 @@ bool OrbitApp::Init() {
 
 //-----------------------------------------------------------------------------
 void OrbitApp::PostInit() {
+#if ORBIT_TRACING_ENABLED
   // Setup introspection handler.
   bool is_service = GOrbitApp->GetHeadless();
-  if(is_service) {
+  if (is_service) {
     auto handler = std::make_unique<orbit::introspection::Handler>();
     LinuxTracing::SetOrbitTracingHandler(std::move(handler));
   }
+#endif  // ORBIT_TRACING_ENABLED
 
   if (HasTcpServer()) {
     GTcpServer->AddCallback(Msg_MiniDump, [=](const Message& a_Msg) {

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -239,7 +239,8 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
     track->OnTimer(a_Timer);
     ++m_ThreadCountMap[a_Timer.m_TID];
     if( a_Timer.m_Type == Timer::INTROSPECTION ) {
-      track->SetColor(Color(87, 166, 74, 255));
+      const Color kGreenIntrospection(87, 166, 74, 255);
+      track->SetColor(kGreenIntrospection);
     }
   } else {
     // Use thead 0 as container for scheduling events.

--- a/OrbitGl/TimeGraph.cpp
+++ b/OrbitGl/TimeGraph.cpp
@@ -235,8 +235,12 @@ void TimeGraph::ProcessTimer(const Timer& a_Timer) {
 
   if (!a_Timer.IsType(Timer::THREAD_ACTIVITY) &&
       !a_Timer.IsType(Timer::CORE_ACTIVITY)) {
-    GetThreadTrack(a_Timer.m_TID)->OnTimer(a_Timer);
+    std::shared_ptr<ThreadTrack> track = GetThreadTrack(a_Timer.m_TID);
+    track->OnTimer(a_Timer);
     ++m_ThreadCountMap[a_Timer.m_TID];
+    if( a_Timer.m_Type == Timer::INTROSPECTION ) {
+      track->SetColor(Color(87, 166, 74, 255));
+    }
   } else {
     // Use thead 0 as container for scheduling events.
     GetThreadTrack(0)->OnTimer(a_Timer);
@@ -582,7 +586,10 @@ void TimeGraph::UpdatePrimitives(bool a_Picking) {
                     "%s %s %s", name, extraInfo.c_str(), time.c_str());
 
                 textBox.SetText(text);
-              } else if (!SystraceManager::Get().IsEmpty()) {
+              } else if( timer.m_Type == Timer::INTROSPECTION) {
+                textBox.SetText(timer.EncodedString());
+              }
+               else if (!SystraceManager::Get().IsEmpty()) {
                 textBox.SetText(SystraceManager::Get().GetFunctionName(
                     timer.m_FunctionAddress));
               } else if (!Capture::IsCapturing()) {

--- a/OrbitGl/Track.cpp
+++ b/OrbitGl/Track.cpp
@@ -22,6 +22,10 @@ Track::Track() {
   m_Picked = false;
   m_Moving = false;
   m_Canvas = nullptr;
+
+  unsigned char alpha = 255;
+  unsigned char grey = 60;
+  m_Color = Color(grey, grey, grey, alpha);
 }
 
 //-----------------------------------------------------------------------------
@@ -31,7 +35,7 @@ void Track::Draw(GlCanvas* a_Canvas, bool a_Picking) {
   auto col = Color(grey, grey, grey, alpha);
   a_Picking ? PickingManager::SetPickingColor(
                   a_Canvas->GetPickingManager().CreatePickableId(this))
-            : glColor4ubv(&col[0]);
+            : glColor4ubv(&m_Color[0]);
 
   float x0 = m_Pos[0];
   float x1 = x0 + m_Size[0];
@@ -53,7 +57,7 @@ void Track::Draw(GlCanvas* a_Canvas, bool a_Picking) {
   if (a_Canvas->GetPickingManager().GetPicked() == this)
     glColor4ub(255, 255, 255, 255);
   else
-    glColor4ubv(&col[0]);
+    glColor4ubv(&m_Color[0]);
 
   glBegin(GL_LINES);
   glVertex3f(x0, y0, TRACK_Z);

--- a/OrbitGl/Track.h
+++ b/OrbitGl/Track.h
@@ -38,6 +38,7 @@ class Track : public Pickable {
   void SetSize(float a_SizeX, float a_SizeY);
   void SetID(uint32_t a_ID) { m_ID = a_ID; }
   uint32_t GetID() const { return m_ID; }
+  void SetColor(Color a_Color) { m_Color = a_Color; }
 
  protected:
   GlCanvas* m_Canvas;
@@ -50,4 +51,5 @@ class Track : public Pickable {
   bool m_Moving;
   std::string m_Name;
   uint32_t m_ID;
+  Color m_Color;
 };

--- a/OrbitLinuxTracing/CMakeLists.txt
+++ b/OrbitLinuxTracing/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(OrbitLinuxTracing PRIVATE
 target_sources(OrbitLinuxTracing PUBLIC
         include/OrbitLinuxTracing/Events.h
         include/OrbitLinuxTracing/Function.h
+        include/OrbitLinuxTracing/OrbitTracing.h
         include/OrbitLinuxTracing/Tracer.h
         include/OrbitLinuxTracing/TracerListener.h)
 
@@ -24,6 +25,7 @@ target_sources(OrbitLinuxTracing PRIVATE
         LibunwindstackUnwinder.cpp
         LibunwindstackUnwinder.h
         MakeUniqueForOverwrite.h
+        OrbitTracing.cpp
         PerfEvent.cpp
         PerfEvent.h
         PerfEventOpen.cpp

--- a/OrbitLinuxTracing/OrbitTracing.cpp
+++ b/OrbitLinuxTracing/OrbitTracing.cpp
@@ -1,5 +1,7 @@
 #include <OrbitLinuxTracing/OrbitTracing.h>
 
+#if ORBIT_TRACING_ENABLED
+
 namespace orbit {
 namespace tracing {
 
@@ -15,3 +17,5 @@ void SetOrbitTracingHandler(std::unique_ptr<orbit::tracing::Handler> handler) {
 }
 
 }  // namespace OrbitLinuxTracing
+
+#endif  // ORBIT_TRACING_ENABLED

--- a/OrbitLinuxTracing/OrbitTracing.cpp
+++ b/OrbitLinuxTracing/OrbitTracing.cpp
@@ -1,0 +1,17 @@
+#include <OrbitLinuxTracing/OrbitTracing.h>
+
+namespace orbit {
+namespace tracing {
+
+std::unique_ptr<orbit::tracing::Handler> GHandler;
+
+}  // namespace tracing
+}  // namespace orbit
+
+namespace LinuxTracing {
+
+void SetOrbitTracingHandler(std::unique_ptr<orbit::tracing::Handler> handler) {
+  orbit::tracing::GHandler = std::move(handler);
+}
+
+}  // namespace OrbitLinuxTracing

--- a/OrbitLinuxTracing/TracerThread.cpp
+++ b/OrbitLinuxTracing/TracerThread.cpp
@@ -1,6 +1,7 @@
 #include "TracerThread.h"
 
 #include <OrbitBase/Logging.h>
+#include <OrbitBase/Tracing.h>
 
 #include <thread>
 
@@ -125,10 +126,12 @@ void TracerThread::Run(
                                      this);
 
   while (!(*exit_requested)) {
+    ORBIT_SCOPE("Tracer Iteration");
     // Sleep if there was no new event in the last iteration so that we are not
     // constantly polling. Don't sleep so long that ring buffers overflow.
     // TODO: Refine this sleeping pattern, possibly using exponential backoff.
     if (!last_iteration_saw_events) {
+      ORBIT_SCOPE("Sleep");
       usleep(IDLE_TIME_ON_EMPTY_RING_BUFFERS_US);
     }
 

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
@@ -1,0 +1,11 @@
+#ifndef ORBIT_LINUX_TRACING_ORBIT_TRACING_H_
+#define ORBIT_LINUX_TRACING_ORBIT_TRACING_H_
+
+#include <OrbitBase/Tracing.h>
+#include <memory.h>
+
+namespace LinuxTracing {
+void SetOrbitTracingHandler(std::unique_ptr<orbit::tracing::Handler> handler);
+}
+
+#endif  // ORBIT_LINUX_TRACING_ORBIT_TRACING_H_

--- a/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
+++ b/OrbitLinuxTracing/include/OrbitLinuxTracing/OrbitTracing.h
@@ -4,8 +4,12 @@
 #include <OrbitBase/Tracing.h>
 #include <memory.h>
 
+#if ORBIT_TRACING_ENABLED
+
 namespace LinuxTracing {
 void SetOrbitTracingHandler(std::unique_ptr<orbit::tracing::Handler> handler);
 }
+
+#endif  // ORBIT_TRACING_ENABLED
 
 #endif  // ORBIT_LINUX_TRACING_ORBIT_TRACING_H_


### PR DESCRIPTION
This PR consists of 4 commits that introduce "instrospection" to Orbit.  The general idea is to visualize Orbit's own performance profile alongside the target application in the capture view.  

Using a set of macros defined in OrbitBase/Tracing.h, we can annotate our code to generate special tracks (in green) on the timeline to help us keep an eye on our own code's performance.

For example, TracerThread.cpp has been annotated with ORBIT_SCOPE("Tracer Iteration"); and ORBIT_SCOPE("Sleep");  While profiling, we can now see our manually instrumented functions (from OrbitService) on the same timeline as our target process.  See tracks with green handles:

![Introspection](https://user-images.githubusercontent.com/3687222/76725454-7f85d580-670b-11ea-8b18-e393305b30ce.png)

The next step will be to add a variable tracking mechanism that will allow us to visualize a graph of tracked variable on a new track in the capture view.  That will be extremely useful to see the rate at which we fill up ring buffers for example.

Note that the macros OrbitBase/Tracing.h can be reused to provide users with the same manual instrumentation features but that will require some additional work which is not in the scope of this PR.