### PR TITLE
Check for target OpenGL::OpenGL

### DIFF
--- a/OrbitGl/CMakeLists.txt
+++ b/OrbitGl/CMakeLists.txt
@@ -118,7 +118,7 @@ else()
   set_target_properties(OrbitGl PROPERTIES EXCLUDE_FROM_ALL ON)
 endif()
 
-if(TARGET OpenGL::GLX AND WITH_GUI)
+if(TARGET OpenGL::GLX AND TARGET OpenGL::OpenGL AND WITH_GUI)
   target_link_libraries(OrbitGl PUBLIC OpenGL::GLX)
 endif()
 


### PR DESCRIPTION
OpenGL::GLX depends on OpenGL::OpenGL even if OpenGL::OpenGL does not exists.

For me this seems like a bug in either the cmake script or the opengl-installation.

But for now this PR should "fix" it.

resolves #197 