### PR TITLE
Remove linux-tools-common from bootstrap-orbit.sh

### DIFF
--- a/bootstrap-orbit.sh
+++ b/bootstrap-orbit.sh
@@ -12,7 +12,8 @@ fi
 sudo apt-get update
 sudo apt-get install -y build-essential
 sudo apt-get install -y libglu1-mesa-dev mesa-common-dev libxmu-dev libxi-dev
-sudo apt-get install -y linux-tools-common qt5-default python3-pip
+sudo apt-get install -y qt5-default
+sudo apt-get install -y python3-pip
 
 echo "Checking if conan is available..."
 which conan >/dev/null


### PR DESCRIPTION
This PR removes the package `linux-tools-common` which is not available anymore
and also not needed anymore from the list of packages that are installed when
running the `bootstrap-orbit.sh` script.